### PR TITLE
NaN fixed now also if isnan is a macro

### DIFF
--- a/include/nan_fix.hpp
+++ b/include/nan_fix.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2014 Erik Zenker, Carlchristian Eckert, Marius Melzer
+ *
+ * This file is part of HASENonGPU
+ *
+ * HASENonGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HASENonGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HASENonGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/**
+ * @author Carlchristian Eckert
+ * @licence GPLv3
+ *
+ */
+
+#pragma once
+
+/**
+ * @brief this allows the use of isnan() for int and unsigned
+ * in the template function fileToVector()
+ */
+inline bool isNaN(const int i){
+  return false;
+}
+
+inline bool isNaN(const unsigned int i){
+  return false;
+}
+
+inline bool isNaN(const float i){
+  return isnan(i);
+}
+
+inline bool isNaN(const double i){
+  return isnan(i);
+}
+
+inline bool isNaN(const long double i){
+  return isnan(i);
+}
+

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -36,24 +36,10 @@
 
 #include <logging.hpp>
 #include <mesh.hpp>
+#include <nan_fix.hpp>
 
 enum RunMode { NONE, GPU_THREADED, CPU, GPU_MPI };
 
-/**
- * @brief this allows the use of isnan() for int
- * in the template function fileToVector()
- */
-inline bool isnan(const int i){
-    return false;
-}
-
-/**
- * @brief this allows the use of isnan() for unsigned
- * in the template function fileToVector()
- */
-inline bool isnan(const unsigned int i){
-    return false;
-}
 
 /**
  * @brief Parses a given file(filename) line by line.
@@ -78,7 +64,7 @@ int fileToVector(const std::string filename, std::vector<T> *v){
     while(fileStream.good()){
       std::getline(fileStream, line);
       value = (T) atof(line.c_str());
-      if(isnan(value)){
+      if(isNaN(value)){
 	dout(V_ERROR) << "NAN in input data: " << filename << std::endl;
 	exit(1);
       }


### PR DESCRIPTION
- new function isNaN() that offers all the overwrites and wraps isnan()
  appropriately
