### PR TITLE
Changes to licensing in sourcefiles (release 1.1)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,11 @@
- HASENonGPU - Licenses
+ HASEonGPU - Licenses
 ================================================================================
 
 **Copyright 2014** Erik Zenker, Carlchristian Eckert, Marius Melzer,
 	    	       Daniel Albach
 
 
-HASENonGPU is a fast GPU-implementation of a Monte-Carlo
+HASEonGPU is a fast GPU-implementation of a Monte-Carlo
 based ASE-Flux simulation
 
 

--- a/example/matlab_example/beta_int.m
+++ b/example/matlab_example/beta_int.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/beta_int3.m
+++ b/example/matlab_example/beta_int3.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/extract_gain_map.m
+++ b/example/matlab_example/extract_gain_map.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/gain.m
+++ b/example/matlab_example/gain.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/laserPumpCladdingExample.m
+++ b/example/matlab_example/laserPumpCladdingExample.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/set_variables.m
+++ b/example/matlab_example/set_variables.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/example/matlab_example/vtk_wedge.m
+++ b/example/matlab_example/vtk_wedge.m
@@ -1,20 +1,20 @@
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
  % Copyright 2013 Daniel Albach, Erik Zenker, Carlchristian Eckert
  %
- % This file is part of HASENonGPU
+ % This file is part of HASEonGPU
  %
- % HASENonGPU is free software: you can redistribute it and/or modify
+ % HASEonGPU is free software: you can redistribute it and/or modify
  % it under the terms of the GNU General Public License as published by
  % the Free Software Foundation, either version 3 of the License, or
  % (at your option) any later version.
  %
- % HASENonGPU is distributed in the hope that it will be useful,
+ % HASEonGPU is distributed in the hope that it will be useful,
  % but WITHOUT ANY WARRANTY; without even the implied warranty of
  % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  % GNU General Public License for more details.
  %
  % You should have received a copy of the GNU General Public License
- % along with HASENonGPU.
+ % along with HASEonGPU.
  % If not, see <http://www.gnu.org/licenses/>.
  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/include/calc_phi_ase.hpp
+++ b/include/calc_phi_ase.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/calc_phi_ase_mpi.hpp
+++ b/include/calc_phi_ase_mpi.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/calc_phi_ase_threaded.hpp
+++ b/include/calc_phi_ase_threaded.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/calc_sample_gain_sum.hpp
+++ b/include/calc_sample_gain_sum.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/cuda_utils.hpp
+++ b/include/cuda_utils.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/cudachecks.hpp
+++ b/include/cudachecks.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/for_loops_clad.hpp
+++ b/include/for_loops_clad.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/geometry.hpp
+++ b/include/geometry.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/importance_sampling.hpp
+++ b/include/importance_sampling.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/interpolation.hpp
+++ b/include/interpolation.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/map_rays_to_prisms.hpp
+++ b/include/map_rays_to_prisms.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/mesh.hpp
+++ b/include/mesh.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/nan_fix.hpp
+++ b/include/nan_fix.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2014 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/progressbar.hpp
+++ b/include/progressbar.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/propagate_ray.hpp
+++ b/include/propagate_ray.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/ray_histogram.hpp
+++ b/include/ray_histogram.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/reflection.hpp
+++ b/include/reflection.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/thrust_device_vector_nowarn.hpp
+++ b/include/thrust_device_vector_nowarn.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/thrust_host_vector_nowarn.hpp
+++ b/include/thrust_host_vector_nowarn.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,27 +1,27 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-// HASEN_ON_GPU_VERSION % 100 is sub-minor version 
-// HASEN_ON_GPU_VERSION / 100 % 1000 is minor version
-// HASEN_ON_GPU_VERSION / 100000 is major version
+// HASE_ON_GPU_VERSION % 100 is sub-minor version 
+// HASE_ON_GPU_VERSION / 100 % 1000 is minor version
+// HASE_ON_GPU_VERSION / 100000 is major version
 
 #pragma once
-#define HASEN_ON_GPU_VERSION 003000
+#define HASE_ON_GPU_VERSION 003000
 

--- a/include/write_matlab_output.hpp
+++ b/include/write_matlab_output.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/write_to_file.hpp
+++ b/include/write_to_file.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/include/write_to_vtk.hpp
+++ b/include/write_to_vtk.hpp
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/calcPhiASE.m
+++ b/src/calcPhiASE.m
@@ -1,6 +1,26 @@
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+ % Copyright 2014 Erik Zenker, Carlchristian Eckert
+ %
+ % This file is part of HASEonGPU
+ %
+ % HASEonGPU is free software: you can redistribute it and/or modify
+ % it under the terms of the GNU General Public License as published by
+ % the Free Software Foundation, either version 3 of the License, or
+ % (at your option) any later version.
+ %
+ % HASEonGPU is distributed in the hope that it will be useful,
+ % but WITHOUT ANY WARRANTY; without even the implied warranty of
+ % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ % GNU General Public License for more details.
+ %
+ % You should have received a copy of the GNU General Public License
+ % along with HASEonGPU.
+ % If not, see <http://www.gnu.org/licenses/>.
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% calcPhiASE %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-% calculates the phiASE values for a given input
+% % calculates the phiASE values for a given input
 % most meshing paramers are given through the function parameters.
 % However, many parameters for optimization of the computation are
 % set in the beginning of the function (adjust as needed)

--- a/src/calc_phi_ase.cu
+++ b/src/calc_phi_ase.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/calc_phi_ase_mpi.cc
+++ b/src/calc_phi_ase_mpi.cc
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <mpi.h>

--- a/src/calc_phi_ase_threaded.cu
+++ b/src/calc_phi_ase_threaded.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/calc_sample_gain_sum.cu
+++ b/src/calc_sample_gain_sum.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/cuda_utils.cu
+++ b/src/cuda_utils.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/for_loops_clad.cu
+++ b/src/for_loops_clad.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/geometry.cu
+++ b/src/geometry.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/importance_sampling.cu
+++ b/src/importance_sampling.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/interpolation.cu
+++ b/src/interpolation.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/logging.cu
+++ b/src/logging.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/main.cu
+++ b/src/main.cu
@@ -1,26 +1,26 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
 
 /**
- * @mainpage HASENonGPU - High performance Amplified Spontaneous EmissioN on GPU
+ * @mainpage HASEonGPU - High performance Amplified Spontaneous EmissioN on GPU
  *
  * Project with HZDR for porting their ASE-code to a GPU cluster.
  *

--- a/src/map_rays_to_prisms.cu
+++ b/src/map_rays_to_prisms.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/mesh.cu
+++ b/src/mesh.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/parser.cu
+++ b/src/parser.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/progressbar.cu
+++ b/src/progressbar.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/propagate_ray.cu
+++ b/src/propagate_ray.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/ray_histogram.cu
+++ b/src/ray_histogram.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/reflection.cu
+++ b/src/reflection.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/write_matlab_output.cu
+++ b/src/write_matlab_output.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/write_to_file.cu
+++ b/src/write_to_file.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 

--- a/src/write_to_vtk.cu
+++ b/src/write_to_vtk.cu
@@ -1,20 +1,20 @@
 /**
  * Copyright 2013 Erik Zenker, Carlchristian Eckert, Marius Melzer
  *
- * This file is part of HASENonGPU
+ * This file is part of HASEonGPU
  *
- * HASENonGPU is free software: you can redistribute it and/or modify
+ * HASEonGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * HASENonGPU is distributed in the hope that it will be useful,
+ * HASEonGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with HASENonGPU.
+ * along with HASEonGPU.
  * If not, see <http://www.gnu.org/licenses/>.
  */
 


### PR DESCRIPTION
- typo: HASENonGPU is now HASEonGPU
- `src/calcPhiASE.m` was missing some license information
- fixes #43
