### PR TITLE
start a glorious time of continous integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,7 @@
+image: coin/archlinux
+
+script:
+  - mkdir build_tmp && cd build_tmp
+  - cmake ..
+  - make
+  - ls -l

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Compiling
    + go to build directory: `cd haseongpu/build`
    + create Makefile `cmake ..`
    + build project : `make`
+
+### Current Compilation Status:
+
+| *branch* | *state* | *description* |
+| -------- | --------| ------------- |
+| **master** | [![Build Status](http://haseongpu.mooo.com/api/badge/github.com/ComputationalRadiationPhysics/haseongpu/status.svg?branch=master)](http://haseongpu.mooo.com/github.com/ComputationalRadiationPhysics/haseongpu) | our stable new releases |
+| **dev**  | [![Build Status](http://haseongpu.mooo.com/api/badge/github.com/ComputationalRadiationPhysics/haseongpu/status.svg?branch=dev)](http://haseongpu.mooo.com/github.com/ComputationalRadiationPhysics/haseongpu) | our development branch |
  
 
 Usage

--- a/utils/cmake/modules/FindCUDA.cmake
+++ b/utils/cmake/modules/FindCUDA.cmake
@@ -555,6 +555,7 @@ if(NOT CUDA_TOOLKIT_ROOT_DIR)
     NAMES nvcc nvcc.exe
     PATHS /usr/local/bin
           /usr/local/cuda/bin
+          /opt/cuda/bin
     DOC "Toolkit location."
     )
 


### PR DESCRIPTION
- add `.drone.yml`
- close #25
- uses drone.io for CI
- docker-image for Arch Linux, created mostly by @erikzenker
- hosted on digitalocean.com
- reachable through haseongpu.mooo.com
- modified `FindCUDA.cmake` to find CUDA_TOOLKIT_ROOT_DIR on Arch Linux
- added build status to README.md