### PR TITLE
parsing completely remastered + config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ Synopsis
       resolutionwill set the lambda resolution to the maximum number
       of absorption or emission values.
 
+    --config=
+      Specify the location of an optional configuration file. This file holds
+      simple key=value pairs that have the same names as the command-line
+      parameters. If values are defined in the file and on the command line,
+      values from the file are overruled. It is not possible to specify
+      --help or --config= in the config file itself.
+      For an example configuration, see the C example (`calcPhiASE.cfg`).
+
 C-Application Templates
 -----------------------
 

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ Usage
   can be started by the following:
 
   1. follow the compile instructions above
-  2. change path "cd example/matlab_example/"
+  2. change path `cd example/matlab_example/`
   3. run : `matlab laserPumpCladdingExample`
   4. watch progress
-  5. take a look at the results (*.vtk) with paraview 
+  5. take a look at the results (`*.vtk`) with paraview
 
 
 ### Quick C-Application laser pump example 
 
   1. follow the compile instructions above
-  2. change path "cd example/c_example/"
+  2. change path `cd example/c_example/`
   3. run : `./bin/calcPhiASE --input-path=./input/cylindrical --min-rays=10000`
   4. watch progress
   5. take a look at the results in the output directory
@@ -312,12 +312,14 @@ Synopsis
       Path to a writable location. Is used to write
       input and output for matlab script.
 
-    --parallel-mode=[|threaded|mpi]  
+    --parallel-mode=[graybat|threaded|mpi]
       Defines the method of parallelization to start the
       simulation with. Mode "threaded" uses pthreads on a single
-      node. Mode "mpi" is a parallel mpi
-      implementation for clusters. Note, that this parameter
-      is currently only available when using `--device-mode=gpu`
+      node. Mode "mpi" is a parallel mpi implementation for clusters. Mode
+      "graybat" is similar to "mpi", but uses the communication framework
+      [GrayBat](https://github.com/ComputationalRadiationPhysics/graybat)
+      instead of plain MPI. Note, that the last 2 parameters
+      are currently only available when using `--device-mode=gpu`
 
     --device-mode=[cpu|gpu]  
       Defines on which hardware the simulation will run.

--- a/example/c_example/calcPhiASE.cfg
+++ b/example/c_example/calcPhiASE.cfg
@@ -1,0 +1,25 @@
+## [Experiment]
+
+input-path=input/cylindrical
+#output-path=output
+#min-rays=100000
+#max-rays=1000000
+#mse-threshold=0.1
+#reflection=true
+#spectral-resolution=
+
+
+## [Compute]
+
+#parallel-mode=threaded
+#device-mode=gpu
+#ngpus=1
+#repetitions=4
+#adaptive-steps=5
+#min-sample-i=0
+#max-sample-i=
+
+
+## [Generic]
+
+verbosity=47

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -21,47 +21,77 @@
 #pragma once
 
 #include <boost/filesystem.hpp> /* fs::path */
+#include <string>
+
 namespace fs = boost::filesystem;
 
 
-enum DeviceMode { NO_DEVICE_MODE, GPU_DEVICE_MODE, CPU_DEVICE_MODE};
-enum ParallelMode { NO_PARALLEL_MODE, THREADED_PARALLEL_MODE, MPI_PARALLEL_MODE, GRAYBAT_PARALLEL_MODE};
+struct DeviceMode {
+    static const std::string NONE;
+    static const std::string GPU;
+    static const std::string CPU;
+};
 
-std::ostream& operator<<(std::ostream& out, const DeviceMode value);
-std::ostream& operator<<(std::ostream& out, const ParallelMode value);
+
+struct ParallelMode {
+    static const std::string NONE;
+    static const std::string THREADED;
+    static const std::string MPI;
+    static const std::string GRAYBAT;
+};
+
+struct CompSwitch{
+    static const std::string parallel_mode;
+    static const std::string device_mode;
+    static const std::string ngpus;
+    static const std::string repetitions;
+    static const std::string adaptive_steps;
+    static const std::string min_sample_i;
+    static const std::string max_sample_i;
+};
+
+struct ExpSwitch{
+    static const std::string input_path;
+    static const std::string output_path;
+    static const std::string min_rays;
+    static const std::string max_rays;
+    static const std::string mse;
+    static const std::string reflection;
+    static const std::string spectral;
+};
 
 struct ComputeParameters {
 
     ComputeParameters() {}
-    
+
     ComputeParameters(  unsigned maxRepetitions,
             unsigned adaptiveSteps,
             unsigned gpu_i,
-            DeviceMode deviceMode,
-            ParallelMode parallelMode,
+            std::string deviceMode,
+            std::string parallelMode,
             bool writeVtk,
             fs::path inputPath,
             fs::path outputPath,
             std::vector<unsigned> devices,
             int minSampleRange,
             int maxSampleRange) :
-	maxRepetitions(maxRepetitions),
-    adaptiveSteps(adaptiveSteps),
-	gpu_i(gpu_i),
-	deviceMode(deviceMode),
-	parallelMode(parallelMode),
-	writeVtk(writeVtk),
-	inputPath(inputPath),
-	outputPath(outputPath),
-	devices(devices),
-	minSampleRange(minSampleRange),
-	maxSampleRange(maxSampleRange){ }
+        maxRepetitions(maxRepetitions),
+        adaptiveSteps(adaptiveSteps),
+        gpu_i(gpu_i),
+        deviceMode(deviceMode),
+        parallelMode(parallelMode),
+        writeVtk(writeVtk),
+        inputPath(inputPath),
+        outputPath(outputPath),
+        devices(devices),
+        minSampleRange(minSampleRange),
+        maxSampleRange(maxSampleRange){ }
 
     unsigned maxRepetitions;
     unsigned adaptiveSteps;
     unsigned gpu_i;
-    DeviceMode deviceMode;
-    ParallelMode parallelMode;
+    std::string deviceMode;
+    std::string parallelMode;
     bool writeVtk;
     fs::path inputPath;
     fs::path outputPath;
@@ -69,52 +99,49 @@ struct ComputeParameters {
     int minSampleRange;
     int maxSampleRange;
 
-    
+
 };
 
 struct Result {
 
     Result(){}
-    
+
     Result( std::vector<float> phiAse,
-	    std::vector<double> mse,
-	    std::vector<unsigned> totalRays,
-	    std::vector<double>   dndtAse) :
-	phiAse(phiAse),
-	mse(mse),
-	totalRays(totalRays),
-	dndtAse(dndtAse){}
-  
+            std::vector<double> mse,
+            std::vector<unsigned> totalRays,
+            std::vector<double>   dndtAse) :
+        phiAse(phiAse),
+        mse(mse),
+        totalRays(totalRays),
+        dndtAse(dndtAse){}
 
     std::vector<float> phiAse;
     std::vector<double> mse;
     std::vector<unsigned> totalRays;
     std::vector<double>   dndtAse;
 
-
-
 };
 
 struct ExperimentParameters {
 
     ExperimentParameters() {}
-    
+
     ExperimentParameters(  unsigned minRaysPerSample,
-			   unsigned maxRaysPerSample,
-			   std::vector<double> sigmaA,
-			   std::vector<double> sigmaE,
-			   double maxSigmaA,
-			   double maxSigmaE,
-			   double mseThreshold,
-			   bool useReflections) :
-	minRaysPerSample(minRaysPerSample),
-	maxRaysPerSample(maxRaysPerSample),
-	sigmaA(sigmaA),
-	sigmaE(sigmaE),
-	maxSigmaA(maxSigmaA),
-	maxSigmaE(maxSigmaE),
-	mseThreshold(mseThreshold),
-	useReflections(useReflections) { }
+            unsigned maxRaysPerSample,
+            std::vector<double> sigmaA,
+            std::vector<double> sigmaE,
+            double maxSigmaA,
+            double maxSigmaE,
+            double mseThreshold,
+            bool useReflections) :
+        minRaysPerSample(minRaysPerSample),
+        maxRaysPerSample(maxRaysPerSample),
+        sigmaA(sigmaA),
+        sigmaE(sigmaE),
+        maxSigmaA(maxSigmaA),
+        maxSigmaE(maxSigmaE),
+        mseThreshold(mseThreshold),
+        useReflections(useReflections) { }
 
     unsigned minRaysPerSample;
     unsigned maxRaysPerSample;
@@ -125,7 +152,4 @@ struct ExperimentParameters {
     double mseThreshold;
     bool useReflections;
 
-
 };
-
-    

--- a/src/main.cc
+++ b/src/main.cc
@@ -51,7 +51,6 @@ namespace fs = boost::filesystem;
 #include <for_loops_clad.hpp>
 #include <cudachecks.hpp>
 #include <mesh.hpp>
-#include <cuda_utils.hpp> /* getFreeDevices */
 #include <logging.hpp>
 #include <ray_histogram.hpp>
 #include <types.hpp>

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -322,13 +322,18 @@ Modifiable_variables_map checkParameterValidity(Modifiable_variables_map vm, con
         exit(1);
     }
 
-    if (!exists(inputPath) || !is_directory(inputPath) || is_empty(inputPath)) {
-        dout(V_ERROR) << "Please specify the experiment's location with --" << ExpSwitch::input_path << "=PATH_TO_EXPERIMENT" << std::endl;
+    if (!exists(inputPath) || !is_directory(inputPath)){
+        dout(V_ERROR) << "The specified input path does not exist, is no directory, or has insufficient permissions. Please specify a correct path by --" << ExpSwitch::output_path << "=[path]" << std::endl;
         exit(1);
+    }else{
+        if(is_empty(inputPath)) {
+            dout(V_ERROR) << "The specified input folder " << ExpSwitch::input_path << " is empty!" << std::endl;
+            exit(1);
+        }
     }
 
     if (!exists(outputPath) || !is_directory(outputPath)) {
-        dout(V_ERROR) << "Please specify the output location with --" << ExpSwitch::output_path << "=PATH_TO_EXPERIMENT" << std::endl;
+        dout(V_ERROR) << "The specified output path does not exist (or permission denied). Please specify a correct folder by --" << ExpSwitch::output_path << "=[path]" << std::endl;
         exit(1);
     }
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -20,34 +20,29 @@
 
 
 #include "types.hpp"
-#include <iostream>
 #include <string>
 
-// Idea from http://stackoverflow.com/questions/3342726/c-print-out-enum-value-as-text
-// Answer by user SigTerm
-// Switched char* to std::string
-//
-std::ostream& operator<<(std::ostream& out, const DeviceMode value){
-    std::string s;
-#define PROCESS_VAL(p) case(p): s = #p; break;
-    switch(value){
-        PROCESS_VAL(NO_DEVICE_MODE);
-        PROCESS_VAL(GPU_DEVICE_MODE);
-        PROCESS_VAL(CPU_DEVICE_MODE);
-    }
-#undef PROCESS_VAL
-    return out << s;
-}
+const std::string DeviceMode::NONE  = "no_device_mode";
+const std::string DeviceMode::GPU   = "gpu";
+const std::string DeviceMode::CPU   = "cpu";
 
-std::ostream& operator<<(std::ostream& out, const ParallelMode value){
-    std::string s;
-#define PROCESS_VAL(p) case(p): s = #p; break;
-    switch(value){
-        PROCESS_VAL(NO_PARALLEL_MODE);
-        PROCESS_VAL(THREADED_PARALLEL_MODE);
-        PROCESS_VAL(MPI_PARALLEL_MODE);
-        PROCESS_VAL(GRAYBAT_PARALLEL_MODE);
-    }
-#undef PROCESS_VAL
-    return out << s;
-}
+const std::string ParallelMode::NONE        = "no_parallel_mode";
+const std::string ParallelMode::THREADED    = "threaded";
+const std::string ParallelMode::MPI         = "mpi";
+const std::string ParallelMode::GRAYBAT     = "graybat";
+
+const std::string CompSwitch::parallel_mode     = "parallel-mode";
+const std::string CompSwitch::device_mode       = "device-mode";
+const std::string CompSwitch::ngpus             = "ngpus";
+const std::string CompSwitch::repetitions       = "repetitions";
+const std::string CompSwitch::adaptive_steps    = "adaptive-steps";
+const std::string CompSwitch::min_sample_i      = "min-sample-i";
+const std::string CompSwitch::max_sample_i      = "max-sample-i";
+
+const std::string ExpSwitch::input_path     = "input-path";
+const std::string ExpSwitch::output_path    = "output-path";
+const std::string ExpSwitch::min_rays       = "min-rays";
+const std::string ExpSwitch::max_rays       = "max-rays";
+const std::string ExpSwitch::mse            = "mse-threshold";
+const std::string ExpSwitch::reflection     = "reflection";
+const std::string ExpSwitch::spectral       = "spectral-resolution";

--- a/src/write_matlab_output.cc
+++ b/src/write_matlab_output.cc
@@ -77,18 +77,15 @@ void writeMatlabOutput(
   fs::ofstream expectedValuesFile;
   const unsigned samplesPerLevel = numberOfSamples/numberOfLevels;
 
-  fs::path asePath(experimentPath);
-  aseFile.open(asePath /= "phi_ASE.txt");
+  aseFile.open(experimentPath / "phi_ASE.txt");
   write3dMatrix(ase, aseFile, samplesPerLevel, numberOfLevels, 1);
   aseFile.close();
 
-  fs::path raysPath(experimentPath);
-  raysFile.open(raysPath /= "N_rays.txt");
+  raysFile.open(experimentPath / "N_rays.txt");
   write3dMatrix(N_rays, raysFile, samplesPerLevel, numberOfLevels, 1);
   raysFile.close();
 
-  fs::path msePath(experimentPath);
-  expectedValuesFile.open(msePath /= "mse_values.txt");
+  expectedValuesFile.open(experimentPath / "mse_values.txt");
   write3dMatrix(expectedValues, expectedValuesFile, samplesPerLevel, numberOfLevels, 1);
   expectedValuesFile.close();
 }


### PR DESCRIPTION
 Maybe there is some stuff missing. Code seems to run great, but it would be good to play with the command-line parameters a bit before accepting the PR.

### Things that are included:
 - there is now a --config parameter which can be used to supply a
   config-file. The c-example already contains an example file.
   The sections ([Compute] etc.) should be commented out!
 - --help and --config can not be defined in the config-file... this is
   intentional.
 - all command-line parameters are no longer directly written in code,
   but abstracted away into the structs in `src/types.cc`
 - the command-line parameters are now structured similarly to the
   existing structs `ComputeParameters` and `ExperimentParameters`
 - The functions `fileToVector` and `fileToValue` now return the result
   instead of taking a reference.
 - the `parse` function was completely remastered and is much smaller
   now. It uses the `variables_map` to encapsulate all command-line
   parameters. I used my own type for the `variables_map`, so we can
   still modify the variables after parsing.
 - DeviceMode and ParallelMode are no longer enums, but std::string.
   This is not ideal, but it makes the code much nicer.
 - As a result, all the nice stuff from #69 was removed again (no longer necessary)
 - closes #10 