### PR TITLE
Add definition to enable M_PI in VS2013

### DIFF
--- a/src/calc_phi_ase.cu
+++ b/src/calc_phi_ase.cu
@@ -21,7 +21,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
+#define _USE_MATH_DEFINES /* make M_PI known for windows */
+#include <cmath>
 #include <assert.h>
 #include <vector>
 #include <curand_kernel.h>

--- a/src/mesh.cu
+++ b/src/mesh.cu
@@ -24,6 +24,7 @@
 #include <string>
 #include <assert.h>
 #include <cfloat>
+#define _USE_MATH_DEFINES /* make M_PI known for windows */
 #include <cmath>
 #include <algorithm>
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -26,6 +26,8 @@
 #include <stdlib.h> /* exit() */
 #include <sstream> /* stringstream */
 #include <functional> /* bind, placeholders */
+#define _USE_MATH_DEFINES /* make M_PI known for windows */
+#include <cmath> /* M_PI */
 
 #include <logging.hpp> 
 #include <mesh.hpp>

--- a/src/reflection.cu
+++ b/src/reflection.cu
@@ -20,8 +20,8 @@
 
 
 #include <assert.h>
-#include <math.h>
-
+#define _USE_MATH_DEFINES /* make M_PI known for windows */
+#include <cmath> /* M_PI */
 #include <reflection.hpp>
 #include <mesh.hpp>
 #include <geometry.hpp>


### PR DESCRIPTION
 - Definition of Pi is present in <cmath> but needs to be enabled for
   windows