### PR TITLE
Added -Werror to CI build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,6 @@ image: coin/archlinux
 script:
   - date
   - mkdir build_tmp && cd build_tmp
-  - cmake -D CUDA_TOOLKIT_ROOT_DIR=/opt/cuda ..
+  - cmake -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda -DCMAKE_CXX_FLAGS="-Werror" ..
   - make
   - ls -l


### PR DESCRIPTION
 - This way, warnings will actually show up as errors in CI, so we can
   fix them
 - -Werror is not enabled for our normal builds, so we are not annoyed
   all the time when developing new stuff