### PR TITLE
Conditional compilation for MPI and Boost.MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ set(LIBS ${LIBS} ${MPI_C_LIBRARIES})
 # bullxmpi fails if it can not find its c++ counter part
 if(MPI_CXX_FOUND)
   set(LIBS ${LIBS} ${MPI_CXX_LIBRARIES})
+  # The define can be used in the code to disable MPI features
+  add_definitions(-DMPI_FOUND)
 endif(MPI_CXX_FOUND)
 
 
@@ -85,7 +87,7 @@ set(LIBS ${LIBS} ${Boost_LIBRARIES})
 
 find_package(Boost 1.50.0 OPTIONAL_COMPONENTS mpi)
 if(Boost_MPI_FOUND)
-    # The define can be used in the code to disable MPI features
+    # The define can be used in the code to disable Boost.MPI features like GrayBat
     add_definitions(-DBOOST_MPI_FOUND)
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     set(LIBS ${LIBS} ${Boost_LIBRARIES})
@@ -188,13 +190,19 @@ warn_path_cuda("C_INCLUDE_PATH")
 ###############################################################################
 set(HASEonGPU_NAME "calcPhiASE")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/graybat)
+file(GLOB SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*")
 
+if(NOT MPI_FOUND)
+    LIST(REMOVE_ITEM SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/include/calc_phi_ase_mpi.cc)
+endif()
+
+if(Boost_MPI_FOUND)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/include/graybat)
+else ()
+    LIST(REMOVE_ITEM SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/include/calc_phi_ase_graybat.cc)
+endif()
 
 cuda_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-file(GLOB SRCFILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*")
 
 cuda_add_executable(${HASEonGPU_NAME} ${SRCFILES})
 

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -37,8 +37,12 @@ struct DeviceMode {
 struct ParallelMode {
     static const std::string NONE;
     static const std::string THREADED;
+#if defined(MPI_FOUND)
     static const std::string MPI;
+#endif
+#if defined(BOOST_MPI_FOUND) || defined(ZMQ_FOUND)
     static const std::string GRAYBAT;
+#endif
 };
 
 struct CompSwitch{

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -342,11 +342,23 @@ Modifiable_variables_map checkParameterValidity(Modifiable_variables_map vm, con
             << CompSwitch::parallel_mode << " \"threaded\"! (will be ignored)" << std::endl;
     }
 
-    if (parallelMode != ParallelMode::GRAYBAT
+    if (parallelMode != ParallelMode::THREADED
+#if defined(MPI_FOUND)
             && parallelMode != ParallelMode::MPI
-            && parallelMode != ParallelMode::THREADED) {
-        dout(V_ERROR) << CompSwitch::parallel_mode << " must be either \"" << ParallelMode::MPI << "\", \""
-            << ParallelMode::GRAYBAT << "\", or \"" << ParallelMode::THREADED << "\"" << std::endl;
+#endif
+#if defined(BOOST_MPI_FOUND) || defined(ZMQ_FOUND)
+            && parallelMode != ParallelMode::GRAYBAT
+#endif
+            ) {
+        dout(V_ERROR) << CompSwitch::parallel_mode << " must be one of \""
+            << ParallelMode::THREADED << "\""
+#if defined(MPI_FOUND)
+            << ", \"" << ParallelMode::MPI << "\""
+#endif
+#if defined(BOOST_MPI_FOUND) || defined(ZMQ_FOUND)
+            << ", \"" << ParallelMode::GRAYBAT << "\""
+#endif
+            << std::endl;
         exit(1);
     }
 


### PR DESCRIPTION
 - CMake will set the defines **MPI_FOUND** and **BOOST_MPI_FOUND** if the
   corresponding files were found during configuration
 - the code has some (not too many, thankfully) new #ifdef instructions
   for the preprocessor, so that lines are excluded if the defines are
   not set.
 - in `CMakeLists.txt`, the files `calc_phi_ase_mpi.cc` and
   `calc_phi_ase_graybat.cc` are removed from the project if the
   requirements are not fulfilled, so they are not built