### PR TITLE
removed typename from calc_phi_ase_graybat.cc

### DIFF
--- a/src/calc_phi_ase_graybat.cc
+++ b/src/calc_phi_ase_graybat.cc
@@ -165,12 +165,12 @@ float calcPhiAseGrayBat ( const ExperimentParameters &experiment,
      **************************************************************************/
     // Configuration
 
-    typedef typename graybat::communicationPolicy::BMPI CP;
-    typedef typename graybat::graphPolicy::BGL<>        GP;
-    typedef typename graybat::Cage<CP, GP>              Cage;
-    typedef typename Cage::Vertex                       Vertex;
-    typedef typename Cage::Edge                         Edge;
-    
+    typedef graybat::communicationPolicy::BMPI CP;
+    typedef graybat::graphPolicy::BGL<>        GP;
+    typedef graybat::Cage<CP, GP>              Cage;
+    typedef Cage::Vertex                       Vertex;
+    typedef Cage::Edge                         Edge;
+
     // Init
     Cage cage;
     const unsigned nPeers = cage.getPeers().size();


### PR DESCRIPTION
`typename` is not required here by gcc and MSVC even throws an error (see #85 )

Probably should be **tested** before we merge (I might do the testing later on)

This fixes #85 