### PR TITLE
Fixed min-sample-i / max-sample-i for GrayBat

### DIFF
--- a/src/calc_phi_ase_graybat.cc
+++ b/src/calc_phi_ase_graybat.cc
@@ -182,8 +182,8 @@ float calcPhiAseGrayBat ( const ExperimentParameters &experiment,
      * ASE SIMULATION
      **************************************************************************/
     // Create sample indices
-    std::vector<unsigned> samples(mesh.numberOfSamples);
-    std::iota(samples.begin(), samples.end(), 0);
+    std::vector<unsigned> samples(1 + compute.maxSampleRange - compute.minSampleRange);
+    std::iota(samples.begin(), samples.end(), compute.minSampleRange);
 
     // Determine phi ase for each sample
     for(Vertex vertex : cage.hostedVertices) {


### PR DESCRIPTION
 - fixed bug: Graybat ignored min-sample-i and max-sample-i command line
   switches. Instead, always the full range was calculated