### PR TITLE
Reflection point in z direction to z plane

### DIFF
--- a/include/reflection.hpp
+++ b/include/reflection.hpp
@@ -62,7 +62,7 @@ ALPAKA_FN_ACC int calcPlaneIntersectionPoint(const Ray reflectionRay, const Refl
     if(length > 0){
       intersectionPoint->x = reflectionRay.p.x + length * reflectionRay.dir.x;
       intersectionPoint->y = reflectionRay.p.y + length * reflectionRay.dir.y;
-      intersectionPoint->z = reflectionRay.p.z + length * reflectionRay.dir.z;
+      intersectionPoint->z = planeZ;
       return 0;
     }
 


### PR DESCRIPTION
Reflection point in z direction is set to the z coordinate of the reflectionplane,
since a ray should in no case leave the gain media.