### PR TITLE
Backport fix 919ddb5 (Reflection point z plane)

### DIFF
--- a/src/reflection.cu
+++ b/src/reflection.cu
@@ -52,7 +52,7 @@ __device__ int calcPlaneIntersectionPoint(const Ray reflectionRay, const Reflect
     if(length > 0){
       intersectionPoint->x = reflectionRay.p.x + length * reflectionRay.dir.x;
       intersectionPoint->y = reflectionRay.p.y + length * reflectionRay.dir.y;
-      intersectionPoint->z = reflectionRay.p.z + length * reflectionRay.dir.z;
+      intersectionPoint->z = planeZ;
       return 0;
     }
 


### PR DESCRIPTION
 - The reflection point could be placed outside the gain medium, since
   the coordinates were always calculared
 - Z-coordinate MUST be on one of the planes by definition, so we can
   set it there (when calculating it, there could be a VERY small
   difference to the real plane, but still a difference)
 - since the file changed, simple cherry-picking of the commit didn't
   work
 - full hash: 919ddb53beba92a6a3903a75e2ee13724ae4e16e