### PR TITLE
Add testing and static library interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 bin/*
 *.~lock.*
 *.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(HASE_CUDA_KEEP_FILES
 )
 option(HASE_CUDA_SHOW_CODELINES "Show kernel lines in cuda-gdb and cuda-memcheck" OFF)
 option(DISABLE_MPI "toggle that allows compilation of haseongpu without requiring the MPI dependency" OFF)
+option(HASE_TESTING "Build unit tests" OFF)
 
 set(HASE_CUDA_ARCHITECTURES native CACHE STRING "CUDA Architectures")
 
@@ -85,48 +86,60 @@ else()
   set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-# calcPhiASE executable target
-add_executable(calcPhiASE)
 
-file(GLOB_RECURSE calcPhiASE_SOURCES CONFIGURE_DEPENDS
+# core library with all sources
+add_library(hase_core STATIC)
+
+file(GLOB_RECURSE HASE_CORE_SOURCES CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cxx"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu"
 )
+list(REMOVE_ITEM HASE_CORE_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu"
+)
+target_sources(hase_core PRIVATE ${HASE_CORE_SOURCES})
 
-target_sources(calcPhiASE PRIVATE ${calcPhiASE_SOURCES})
-target_include_directories(calcPhiASE PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
-
-set_target_properties(calcPhiASE PROPERTIES
-  CUDA_SEPARABLE_COMPILATION ON
-  CUDA_ARCHITECTURES "${HASE_CUDA_ARCHITECTURES}"
+target_include_directories(hase_core PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
-target_compile_options(calcPhiASE PRIVATE
-  "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:${HASE_NVCC_FLAGS}>"
-  "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:${HASE_GCC_FLAGS}>"
-  "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${HASE_CLANG_FLAGS}>"
+set_target_properties(hase_core PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_ARCHITECTURES "${HASE_CUDA_ARCHITECTURES}"
 )
 
-target_link_libraries(calcPhiASE PRIVATE
-  Boost::program_options
-  Threads::Threads
-  CUDA::cudart
+target_compile_options(hase_core PRIVATE
+        "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:${HASE_NVCC_FLAGS}>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:${HASE_GCC_FLAGS}>"
+        "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${HASE_CLANG_FLAGS}>"
 )
-#enable/disable mpi dependency based on cmake option
+
+target_link_libraries(hase_core PUBLIC
+        Boost::program_options
+        Threads::Threads
+        CUDA::cudart
+)
+
+# enable/disable mpi dependency based on cmake option
 if(NOT DISABLE_MPI)
-    find_package(MPI REQUIRED COMPONENTS C)
-    target_link_libraries(calcPhiASE PRIVATE MPI::MPI_C)
-    target_compile_definitions(calcPhiASE PRIVATE OMPI_SKIP_MPICXX)
+  find_package(MPI REQUIRED COMPONENTS C)
+  target_link_libraries(hase_core PUBLIC MPI::MPI_C)
+  target_compile_definitions(hase_core PUBLIC OMPI_SKIP_MPICXX)
 else()
-    target_compile_definitions(calcPhiASE PRIVATE DISABLE_MPI)
+  target_compile_definitions(hase_core PUBLIC DISABLE_MPI)
 endif()
+# enable Testing
+if(HASE_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+# (keep your CUDA props / flags / link libs on hase_core as discussed)
 
-# add target
-add_custom_target(examples ALL
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:calcPhiASE>
-        ${CMAKE_CURRENT_BINARY_DIR}/calcPhiASE
-        DEPENDS calcPhiASE
-)
+
+# --- main executable: main.cu + core lib ---
+add_executable(calcPhiASE "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cu")
+
+target_link_libraries(calcPhiASE PRIVATE hase_core)

--- a/src/logging_globals.cu
+++ b/src/logging_globals.cu
@@ -1,0 +1,5 @@
+/**
+* Copyright 2026 Tim Hanel
+**/
+#include "logging.hpp"
+unsigned verbosity = V_ERROR | V_INFO | V_WARNING | V_PROGRESS | V_STAT;

--- a/src/main.cu
+++ b/src/main.cu
@@ -50,10 +50,7 @@
 #include <cuda_utils.hpp> /* getFreeDevices */
 #include <logging.hpp>
 #include <ray_histogram.hpp>
-#include <interpolation.hpp> /* interpolateWavelength*/
-
-// default without V_DEBUG
-unsigned verbosity = V_ERROR | V_INFO | V_WARNING | V_PROGRESS | V_STAT; // extern through logging.hpp
+#include <interpolation.hpp> /* interpolateLinear*/
 
 /** 
  * @brief Calculates dndt ASE from phi ASE values
@@ -125,8 +122,8 @@ int main(int argc, char **argv){
   if(fileToVector(inputPath + "sigmaE.txt",  &sigmaE))   return 1;
   if(fileToVector(inputPath + "lambdaA.txt", &lambdaA)) return 1;
   if(fileToVector(inputPath + "lambdaE.txt", &lambdaE)) return 1;
-  lambdaResolution = std::max(lambdaResolution, (unsigned) lambdaA.size());
-  lambdaResolution = std::max(lambdaResolution, (unsigned) lambdaE.size());
+  lambdaResolution = std::max(lambdaResolution, static_cast<unsigned>(lambdaA.size()));
+  lambdaResolution = std::max(lambdaResolution, static_cast<unsigned>(lambdaE.size()));
   
   assert(sigmaA.size() == lambdaA.size());
   assert(sigmaE.size() == lambdaE.size());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.24)
+
+include(FetchContent)
+
+# Catch2 v3
+FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG v3.6.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Collect all test translation units in this folder (cpp + cu)
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/*.cu"
+)
+
+add_executable(hase_tests ${TEST_SOURCES})
+
+# Inherit all include dirs, compile options, defines, and link libs via hase_core
+target_link_libraries(hase_tests PRIVATE
+        hase_core
+        Catch2::Catch2WithMain
+)
+
+# If your tests include CUDA code and need separable compilation too:
+set_target_properties(hase_tests PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_ARCHITECTURES "${HASE_CUDA_ARCHITECTURES}"
+)
+
+include(CTest)
+include(Catch)
+
+catch_discover_tests(hase_tests)


### PR DESCRIPTION
- Integrate an internal static library interface to persist CMake configuration across translation units, enabling testing/benchmarks and additional CUDA examples based on the existing implementations and headers. 

- Adds a  cmake flag `HASE_TESTING` and a tests/CMakeLists.txt, which links all generated testing source files in tests/ to the static library. 

- Includes Catch2 (automatically installed via fetchContent) + CTest for testing purposes - if cmake flag is specified.