### PR TITLE
fix compute parameters being parsed incorrectly

### DIFF
--- a/docs/source/binaryInterface.rst
+++ b/docs/source/binaryInterface.rst
@@ -53,7 +53,7 @@ Single-node threaded run using the ``cylindrical`` example:
        --device-mode=gpu \
        --min-rays=10000 \
        --max-rays=100000 \
-       --reflection \
+       --reflection=1 \
        --repetitions=4 \
        --adaptive-steps=4 \
        --ngpus=4 \
@@ -72,7 +72,7 @@ MPI run with 4 GPUs per node using the same example:
        --device-mode=gpu \
        --min-rays=10000 \
        --max-rays=100000 \
-       --reflection \
+       --reflection=1 \
        --repetitions=4 \
        --adaptive-steps=4 \
        --ngpus=1 \
@@ -155,10 +155,16 @@ Verbosity level interpreted as a bitmask. Multiple values can be combined.
 * ``16``: debug
 * ``32``: progress bar
 
-``--reflection``
+``--reflection=``
 ^^^^^^^^^^^^^^^^
 
 Enables reflections on the upper and lower surfaces of the gain medium.
+
+``1``
+    enabled
+
+``0``
+    disabled
 
 ``--mse-threshold=``
 ^^^^^^^^^^^^^^^^^^^^

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -459,8 +459,8 @@ int parse( const int argc,
             vm[ExpSwitch::mse].as<double>(),
             vm[ExpSwitch::reflection].as<bool>() );
 
-    auto &repetionOpt=vm[ExpSwitch::min_rays];
-    auto &adaptiveStepOpt=vm[ExpSwitch::max_rays];
+    auto &repetionOpt=vm[CompSwitch::repetitions];
+    auto &adaptiveStepOpt=vm[CompSwitch::adaptive_steps];
     checkPositive(repetionOpt.as<int>(),repetionOpt.name);
     checkPositive(adaptiveStepOpt.as<int>(),adaptiveStepOpt.name);
     compute = ComputeParameters (


### PR DESCRIPTION
Notably the parameters `--repetitions` and `--adaptive-steps` had previously no effect and where actually overwritten by false values. 
This did not surface when using the python interface since the binding already ensured consistent parsing. 
The PR also includes a small correction in the documentation regarding the binaryInterface.