### PR TITLE
fix calcIntersectionAngle by using floating-point abs

### DIFF
--- a/src/reflection.cu
+++ b/src/reflection.cu
@@ -27,8 +27,8 @@
 #include <geometry.hpp>
 
 __device__ double calcIntersectionAngle(const Ray ray, double *reflectionAngle){
-  // Calc intesection angle with z-plane
-  double nominator = abs(ray.dir.z);
+  // Calc intersection angle with z-plane
+  double nominator = fabs(ray.dir.z);
   double denominator = sqrt((ray.dir.x * ray.dir.x) + (ray.dir.y * ray.dir.y) + (ray.dir.z * ray.dir.z));
   if(denominator != 0.0){
     double radian = acos(nominator / denominator);


### PR DESCRIPTION

This PR fixes `calcIntersectionAngle()` by using the correct floating-point absolute-value fabs() function for `ray.dir.z`.

Previously, the code called the wrong `abs()` overload in some build configurations. In those cases, the floating-point `z` component was converted to an integer before taking the absolute value. This effectively truncated the value, causing incorrect reflection angles to be calculated.