### PR TITLE
fix mse threshhold issue in laserPumpCladding

### DIFF
--- a/example/python_example/config/phiASE.yaml
+++ b/example/python_example/config/phiASE.yaml
@@ -1,8 +1,8 @@
 experiment:
   minRaysPerSample: 1000
-  maxRaysPerSample: 100000
-  mseThreshold: 0.005
-  adaptiveSteps: 3
+  maxRaysPerSample: 1000000
+  mseThreshold: 0.01087 # this is the volume weighting adjusted threshold (scaled the original 0.005 by thickness * mesh.surface )
+  adaptiveSteps: 8
   useReflections: true
 
 compute:

--- a/example/python_example/legacy/laserPumpCladdingExample.py
+++ b/example/python_example/legacy/laserPumpCladdingExample.py
@@ -87,6 +87,7 @@ def main(
     timeslice_total_override: int | None = None,
     min_sample_range: int = 0,
     max_sample_range: int | None = None,
+    mse_threshold_override: float | None = None,
     snapshot_path: Path | None = None,
 ):
     print(f' root: {SCRIPT_DIR}')
@@ -174,7 +175,8 @@ def main(
     adaptiveSteps = 5 if adaptive_steps_override is None else int(adaptive_steps_override)
     minRaysPerSample = 1e5 if min_rays is None else int(min_rays)
     maxRaysPerSample = minRaysPerSample * 100 if max_rays is None else int(max_rays)
-    mseThreshold = 0.005
+    # this is the volume weighting adjusted threshold (scaled the original 0.005 by thickness * mesh.surface )
+    mseThreshold = 0.01087 if mse_threshold_override is None else float(mse_threshold_override)
 
     ## this is our starting counter
     tic= time.perf_counter()
@@ -564,6 +566,12 @@ if __name__ == "__main__":
         help="Override the number of phiASE adaptive ray-count steps for this run",
     )
     parser.add_argument(
+        "--mse-threshold",
+        type=float,
+        default=None,
+        help="Override the phiASE MSE threshold for this run",
+    )
+    parser.add_argument(
         "--reflection",
         type=int,
         choices=(0, 1),
@@ -617,6 +625,7 @@ if __name__ == "__main__":
         use_reflections_override=None if args.reflection is None else bool(args.reflection),
         repetitions_override=args.repetitions,
         adaptive_steps_override=args.adaptive_steps,
+        mse_threshold_override=args.mse_threshold,
         timeslice_override=args.timeslice,
         timeslice_total_override=args.timeslice_total,
         min_sample_range=args.min_sample_range,

--- a/include/core/calcPhiAse.hpp
+++ b/include/core/calcPhiAse.hpp
@@ -53,6 +53,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 #define SEED 4321
 
@@ -69,12 +70,15 @@ namespace hase::core
     };
 
     template<std::floating_point T_Elem>
-    T_Elem calcMSE(T_Elem const phiAse, T_Elem const phiAseSquare, unsigned const raysPerSample)
+    T_Elem calcMSE(T_Elem const gainSum, T_Elem const gainSumSquare, unsigned const raysPerSample)
     {
-        T_Elem a = phiAseSquare / raysPerSample;
-        T_Elem b = (phiAse / raysPerSample) * (phiAse / raysPerSample);
+        if(raysPerSample < 2)
+            return std::numeric_limits<T_Elem>::max();
 
-        return alpaka::math::sqrt(alpaka::math::abs((a - b) / raysPerSample));
+        auto const n = static_cast<T_Elem>(raysPerSample);
+        T_Elem const varianceOfMean = (gainSumSquare - gainSum * gainSum / n) / (n * (n - 1));
+
+        return alpaka::math::sqrt(alpaka::math::max(T_Elem{0}, varianceOfMean)) / (T_Elem{4} * M_PI);
     }
 
     inline std::vector<int> generateRaysPerSampleExpList(int minRaysPerSample, int maxRaysPerSample, int steps)
@@ -307,19 +311,24 @@ namespace hase::core
                     alpaka::onHost::memcpy(queue, hgainSumView, dGainSum);
                     alpaka::onHost::memcpy(queue, hgainSumSquareView, dGainSumSquare);
                     alpaka::onHost::wait(queue);
-                    float mseTmp = calcMSE(gainSumHost, gainSumSquareHost, hRaysPerSampleDump);
+                    double mseTmp = calcMSE(gainSumHost, gainSumSquareHost, hRaysPerSampleDump);
 
                     assert(!alpaka::math::isnan(hgainSumView[0]));
                     assert(!alpaka::math::isnan(hgainSumSquareView[0]));
                     assert(!alpaka::math::isnan(mseTmp));
-
-                    if(result.mse.at(sampleIdx) > mseTmp)
+                    auto updateSample = [&]()
                     {
                         result.mse.at(sampleIdx) = mseTmp;
                         result.phiAse.at(sampleIdx) = gainSumHost;
                         result.phiAse.at(sampleIdx) /= *raysPerSampleIter * 4.0f * M_PI;
                         result.totalRays.at(sampleIdx) = *raysPerSampleIter;
+                    };
+
+                    if(result.mse.at(sampleIdx) > mseTmp)
+                    {
+                        updateSample();
                     }
+
                     if(result.mse.at(sampleIdx) < experiment.mseThreshold)
                         mseTooHigh = false;
                 }

--- a/src/parse/parser.cpp
+++ b/src/parse/parser.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib> /* exit() */
 #include <filesystem>
 #include <functional> /* bind, placeholders */
+#include <limits>
 #include <optional>
 #include <ranges>
 #include <sstream> /* stringstream */
@@ -413,7 +414,7 @@ namespace hase::parse
     {
         result = hase::core::Result(
             std::vector<float>(numberOfSamples, 0.0f),
-            std::vector<double>(numberOfSamples, 100000.0),
+            std::vector<double>(numberOfSamples, std::numeric_limits<double>::max()),
             std::vector<unsigned>(numberOfSamples, 0u),
             std::vector<double>(numberOfSamples, 0.0));
     }

--- a/tests/compSerial_Itest.cpp
+++ b/tests/compSerial_Itest.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -82,7 +83,7 @@ void runSerial(TestData& testData)
 void resetResultForSimulation(hase::core::Result& result)
 {
     std::ranges::fill(result.phiAse, 0.0f);
-    std::ranges::fill(result.mse, 100000.0);
+    std::ranges::fill(result.mse, std::numeric_limits<double>::max());
     std::ranges::fill(result.totalRays, 0u);
     std::ranges::fill(result.dndtAse, 0.0);
 }

--- a/tests/data/cfg/legacy_config.yaml
+++ b/tests/data/cfg/legacy_config.yaml
@@ -1,7 +1,7 @@
 experiment:
   minRaysPerSample: 1000
   maxRaysPerSample: 100000
-  mseThreshold: 0.005
+  mseThreshold: 0.01087
   useReflections: true
   monochromatic: false
 

--- a/tests/python/phiAse/test_analyticalSphere.py
+++ b/tests/python/phiAse/test_analyticalSphere.py
@@ -119,38 +119,36 @@ def constructBetaCellsSphere(topology, *, center=(5.0, 5.0, 5.0), radius=5.0, be
             if r < radius:
                 betaCells[pointIndex, levelIndex] = float(beta)
     return betaCells
-
+nTot = np.float64(1.38e20 * 1.0)
+sigmaA = np.float64(0.11e-20)
+sigmaE = np.float64(2.1e-20)
 sphereCases = [
     (np.float64(radiusValue), np.float64(g0Value / 100))
     for radiusValue in [0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 50.0, 70.0, 100.0]
-    for g0Value in range(5, 50, 5)
-    if 3.0 <= np.float64(radiusValue) * np.float64(g0Value / 100) <= 5.0
+    for g0Value in range(10, 405, 10)
+    if 5.0 >= np.float64(radiusValue) * np.float64(g0Value / 100) >= 1.0 >= calcBetaFromGain(g0Value/ 100, nTot, sigmaA, sigmaE) >= 0.0
 ]
 
 
 sphereCaseIds = [f"R{float(radius):g}_g0_{float(g0):.2f}" for radius, g0 in sphereCases]
 alpakaBackends = AlpakaBackends.all()
-
-
 @pytest.mark.parametrize("backend", alpakaBackends)
 @pytest.mark.parametrize(("radius", "g0"), sphereCases, ids=sphereCaseIds)
 def testCenterPointIntegralMatchesAnalyticalSolution(radius, g0, backend, phiAseTestConfigPath):
-    # g_0 von 0.05-0.5 [cm^-1], g_0R max 5 (ab g_0R > 3)
     xDim = radius * 2.0
-    nTot = np.float64(1.388e20 * 2.0)
-    sigmaA = np.float64(1.0e-24)
-    sigmaE = np.float64(1.0e-20)
+    nTot = np.float64(1.38e20 * 1.0)
+    sigmaA = np.float64(0.11e-20)
+    sigmaE = np.float64(2.1e-20)
     gain = g0
     beta = calcBetaFromGain(gain, nTot, sigmaA=sigmaA, sigmaE=sigmaE)
     print(f' running with: g0: {g0} and radius: {radius} and beta: {beta}')
     flourescenceLifetime = np.float64(9.41e-4)
 
     crossSections = SpectralDecomposition.monochromatic(
-        wavelength=np.float64(940e-9),
+        wavelength=np.float64(1030e-9),
         crossSectionAbsorption=sigmaA,
         crossSectionEmission=sigmaE,
     )
-
     center = (radius, radius, radius)
 
     grid = Grid(xExtent=xDim, yExtent=xDim, zExtent=xDim, tileSizeX=xDim / 100)
@@ -159,7 +157,6 @@ def testCenterPointIntegralMatchesAnalyticalSolution(radius, g0, backend, phiAse
     betaCells = constructBetaCellsSphere(topology, center=center, radius=radius, beta=beta)
     betaVolume = constructBetaVolumeSphere(topology, center=center, radius=radius, beta=beta)
     flatBetaVolume = betaVolume.reshape(-1, order="F")
-
     assert np.any(flatBetaVolume > 0.0)
     assert np.any(betaCells > 0.0)
     cells = medium.get("betaCells").expectedShape

--- a/tests/python/phiAse/test_analyticalSphere.py
+++ b/tests/python/phiAse/test_analyticalSphere.py
@@ -124,8 +124,8 @@ sigmaA = np.float64(0.11e-20)
 sigmaE = np.float64(2.1e-20)
 sphereCases = [
     (np.float64(radiusValue), np.float64(g0Value / 100))
-    for radiusValue in [0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 50.0, 70.0, 100.0]
-    for g0Value in range(10, 405, 10)
+    for radiusValue in np.geomspace(0.1, 100, num=9)
+    for g0Value in np.geomspace(5, 400, num=9)
     if 5.0 >= np.float64(radiusValue) * np.float64(g0Value / 100) >= 1.0 >= calcBetaFromGain(g0Value/ 100, nTot, sigmaA, sigmaE) >= 0.0
 ]
 
@@ -177,7 +177,7 @@ def testCenterPointIntegralMatchesAnalyticalSolution(radius, g0, backend, phiAse
         maxRaysPerSample=100000,
         repetitions=2,
         adaptiveSteps=3,
-        mseThreshold=0.1,
+        mseThreshold=0.05,
         useReflections=False,
         backend=backend,
         parallelMode="single",
@@ -209,8 +209,105 @@ def testCenterPointIntegralMatchesAnalyticalSolution(radius, g0, backend, phiAse
     # assert numerical > 0.0
     #
     # vtkWedge("phi0.vtk", data=phiAse, geometry=medium.topology,field="phiAse")
-    assert np.isclose(numerical, expected, rtol=0.1)
+    assert np.isclose(numerical, expected, rtol=0.05)
+def make_grid_within_radius(radius: float):
+    return [
+        (x, y)
+        for x in [i * radius / 10 for i in range(-10, 11)]
+        for y in [j * radius / 10 for j in range(-10, 11)]
+        if x * x + y * y <= radius * radius
+    ]
+diskCases = [
+    (np.float64(radiusValue), np.float64(g0Value / 100))
+    for radiusValue in [0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 50.0, 70.0, 100.0]
+    for g0Value in range(10, 405, 10)
+    if 1.0 >= calcBetaFromGain(g0Value / 100, nTot, sigmaA, sigmaE) >= 0.0 and (g0Value / 100) * radiusValue == 2.0
+]
 
+diskCaseIds = [f"R{float(radius):g}_g0_{float(g0):.2f}" for radius, g0 in diskCases]
+@pytest.mark.parametrize(("radius", "g0"), diskCases, ids=diskCaseIds)
+def testDiskPointsMatchAnalyticalSolutionForG02(radius, g0, phiAseTestConfigPath):
+    global expected
+    backend=alpakaBackends[-1]
+    xDim = radius * 2.0
+    nTot = np.float64(1.38e20 * 1.0)
+    sigmaA = np.float64(0.11e-20)
+    sigmaE = np.float64(2.1e-20)
+    gain = g0
+    beta = calcBetaFromGain(gain, nTot, sigmaA=sigmaA, sigmaE=sigmaE)
+    print(f' running with: g0: {g0} and radius: {radius} and beta: {beta}')
+    flourescenceLifetime = np.float64(9.41e-4)
+
+    crossSections = SpectralDecomposition.monochromatic(
+        wavelength=np.float64(1030e-9),
+        crossSectionAbsorption=sigmaA,
+        crossSectionEmission=sigmaE,
+    )
+    center = (radius, radius, radius)
+
+    grid = Grid(xExtent=xDim, yExtent=xDim, zExtent=xDim, tileSizeX=xDim / 100)
+    topology = MeshTopology.fromGrid(grid)
+    medium = GainMedium(topology=topology)
+    betaCells = constructBetaCellsSphere(topology, center=center, radius=radius, beta=beta)
+    betaVolume = constructBetaVolumeSphere(topology, center=center, radius=radius, beta=beta)
+    flatBetaVolume = betaVolume.reshape(-1, order="F")
+    assert np.any(flatBetaVolume > 0.0)
+    assert np.any(betaCells > 0.0)
+    cells = medium.get("betaCells").expectedShape
+    volume = medium.get("betaVolume").expectedShape
+    print(f'betaCells: {cells}, betaVolume: {volume}')
+    medium.withPhysicalProperties(
+        betaCells=betaCells,
+        betaVolume=betaVolume,
+        nTot=nTot,
+        crystalTFluo=flourescenceLifetime,
+    )
+    expectedValues=[]
+    for offsetX,offsetY in make_grid_within_radius(radius):
+        center = (radius+offsetX, radius+offsetY, radius)
+        centerSample = medium.betaCellIndexAt(*center, flat=True)
+        phiAse = PhiASE.fromYaml(
+            phiAseTestConfigPath,
+            spectralProperties=crossSections,
+            minRaysPerSample=10000,
+            maxRaysPerSample=100000,
+            repetitions=2,
+            adaptiveSteps=3,
+            mseThreshold=0.05,
+            useReflections=False,
+            backend=backend,
+            parallelMode="single",
+            numDevices=1,
+            minSampleRange=centerSample,
+            maxSampleRange=centerSample,
+            monochromatic=True,
+        )
+        try:
+            phiAse.run(gainMedium=medium)
+        except RuntimeError as exc:
+            if "return code 1" in str(exc):
+                pytest.skip(f"backend {backend} is not available in this build")
+            raise
+        result = phiAse.getResults()
+        shape = medium.get("betaCells").expectedShape
+        phiAseValues = np.array(result.phiAse, dtype=np.float64).reshape(shape, order="F")
+        numerical = phiAseValues.reshape(-1, order="F")[centerSample]
+
+        expected = analyticalPhiAseSphereCenter(
+            gain=gain,
+            radius=radius,
+            beta=beta,
+            nTot=nTot,
+            tauRad=flourescenceLifetime
+        )
+        print(f'expected: {expected}, numerical {numerical}')
+        # assert np.isfinite(numerical)
+        # assert numerical > 0.0
+        #
+        # vtkWedge("phi0.vtk", data=phiAse, geometry=medium.topology,field="phiAse")
+        assert np.isclose(numerical, expected, rtol=0.05)
+        expectedValues.append(expected)
+    assert all(np.allclose(a, expected[0], rtol=0.2) for a in expected[1:])
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/python/simulation/test_legacyComparison.py
+++ b/tests/python/simulation/test_legacyComparison.py
@@ -51,6 +51,8 @@ def _runLegacyScript(workdir, phiAseConfig, backend, minSample_i, maxSample_i):
         str(compute["repetitions"]),
         "--adaptive-steps",
         str(compute["adaptiveSteps"]),
+        "--mse-threshold",
+        str(experiment["mseThreshold"]),
         "--timeslice",
         "50",
         "--timeslice-total",


### PR DESCRIPTION
The volumetric Monte Carlo weighting introduced in #151 scaled MSE values as a side effect. This resulted in drastically extended runtimes, observed in scripts such as laserPumpCladding.py and legacy/laserPumpCladdingExample.py, since they still used the old unscaled MSE threshold.

By adjusting the original threshold used in these scripts (0.005) by mesh.thickness * mesh.surface,  a volumetric compensation term is applied, which is equivalent to the overall resulting phiASE shift from #151.

Additionally this PR enforces test_analytical_solution to only use a beta within [0,1], aswell as extending the possible value range for g0. 