### PR TITLE
Documentation build fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,12 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    post_install:
+      - python -m pip install -e .
 
 sphinx:
   configuration: docs/source/conf.py
@@ -11,5 +14,3 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,9 +20,6 @@ release = 'master'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../..'))
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/theoryAndModel.rst
+++ b/docs/source/theoryAndModel.rst
@@ -42,14 +42,14 @@ For a prism index
 
    j = t + z N_{\mathrm{tri}},
 
-``t`` is the 2D triangle index, ``z`` is the layer index, and
-``N_{\mathrm{tri}}`` is the number of base triangles.  The prism volume is
+:math:`t` is the 2D triangle index, :math:`z` is the layer index, and
+:math:`N_{\mathrm{tri}}` is the number of base triangles.  The prism volume is
 
 .. math::
 
    V_j = A_t \Delta z,
 
-where ``A_t`` is the triangle area and ``Delta z`` is the layer thickness.
+where :math:`A_t` is the triangle area and :math:`\Delta z` is the layer thickness.
 
 For a source point ``q`` inside prism ``j``, HASEonGPU propagates a ray from
 ``q`` to ``p_i``.  Along that ray the path is split into prism segments
@@ -109,7 +109,7 @@ this raw importance:
    \frac{I_j^{\mathrm{raw}}}{S} N
    \right\rfloor,
 
-where ``N`` is ``ctx.NumRays``.  Any leftover rays caused by integer rounding
+where :math:`N` is ``ctx.NumRays``.  Any leftover rays caused by integer rounding
 are distributed randomly over the prisms.  If ``N_j`` rays are drawn from prism
 ``j``, then ``N_j / N`` approximates the sampling probability.  The final
 Monte Carlo weight is not the raw importance.  It is the prism volume corrected
@@ -131,7 +131,7 @@ In the serial code this is the assignment
    0, & N_j = 0,
    \end{cases}
 
-with ``A_t = surface_new[t]`` and ``Delta z = z_mesh``.
+with :math:`A_t` = ``surface_new[t]`` and :math:`\Delta z` = ``z_mesh``.
 
 The unscaled ASE flux estimator at sample point ``i`` is therefore
 
@@ -146,9 +146,9 @@ The unscaled ASE flux estimator at sample point ``i`` is therefore
    G(q_{j,k} \rightarrow p_i)
    W_j,
 
-where ``N_real`` is the actual number of rays used after integer ray allocation.
-For the serial implementation, ``N_real`` is the accumulated sum of allocated
-``N_j`` values for that sample.
+where :math:`N_{\mathrm{real}}` is the actual number of rays used after integer ray allocation.
+For the serial implementation, :math:`N_{\mathrm{real}}` is the accumulated sum of allocated
+:math:`N_j` values for that sample.
 
 The value returned by the high-level HASEonGPU backend as ``phiAse`` is already
 scaled by active-ion density and fluorescence lifetime:
@@ -161,7 +161,7 @@ scaled by active-ion density and fluorescence lifetime:
    \Phi_i^{0}.
 
 This convention matters for time stepping: ``phiAse`` already contains the
-``N_tot / tau`` factor.
+:math:`N_{\mathrm{tot}} / \tau` factor.
 
 ASE Population Derivative
 -------------------------
@@ -178,8 +178,8 @@ returned ``phiAse`` as
    \right]
    \Phi_i.
 
-Because ``Phi_i`` already includes ``N_tot / tau``, this derivative must not be
-multiplied by ``N_tot`` or divided by ``tau`` again.
+Because :math:`\Phi_i` already includes :math:`N_{\mathrm{tot}} / \tau`, this derivative must not be
+multiplied by :math:`N_{\mathrm{tot}}` or divided by :math:`\tau` again.
 
 Pump and Time Stepping
 ----------------------

--- a/pyInclude/__init__.py
+++ b/pyInclude/__init__.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Public Python convenience exports for HASEonGPU."""
+
 import HASEonGPU_Bindings
 from .alpakaUtils import AlpakaBackends
 from .calcPhiASE import calcPhiASE

--- a/pyInclude/alpakaUtils/AlpakaBackends.py
+++ b/pyInclude/alpakaUtils/AlpakaBackends.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Query Alpaka backend names compiled into the local HASEonGPU build."""
+
 import ctypes
 import ctypes.util
 import sys
@@ -72,14 +74,22 @@ def _loadBackendNames():
 
 
 class AlpakaBackends:
+    """Namespace of backend strings accepted by ``PhiASE`` and ``calcPhiASE``.
+
+    Backend availability depends on how the C++ extension was compiled. Use
+    ``AlpakaBackends.all()`` to inspect the strings for this environment.
+    """
+
     _known = _loadBackendNames()
 
     @classmethod
     def all(cls):
+        """Return all backend names reported by the compiled helper library."""
         return list(cls._known)
 
     @classmethod
     def known(cls):
+        """Alias for ``all()`` kept for discoverability."""
         return cls.all()
 
 

--- a/pyInclude/calcPhiASE.py
+++ b/pyInclude/calcPhiASE.py
@@ -4,6 +4,13 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Legacy Python wrapper for direct ``calcPhiASE`` calls.
+
+New code should usually use ``PhiASE`` from ``simulation.py``. This module
+keeps the historical many-argument function and the temporary-file MPI path for
+compatibility with old scripts.
+"""
+
 import shutil
 import warnings
 
@@ -15,6 +22,7 @@ Mesh=HASEonGPU_Bindings.HostMesh
 
 ############################## cleanIOFiles #################################
 def cleanIOFiles(TMP_FOLDER):
+    """Remove a temporary legacy input/output directory if it exists."""
     if os.path.exists(TMP_FOLDER) and os.path.isdir(TMP_FOLDER):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -30,6 +38,11 @@ def createCalcPhiASEInput(
         claddingNumber,
         claddingAbsorption,
         FOLDER):
+    """Write text input files consumed by the ``calcPhiASE`` binary.
+
+    ``packed`` contains flattened geometry, beta, material, and spectral arrays.
+    The files mirror the historical MATLAB/Python interface layout.
+    """
 
     CURRENT_DIR = os.getcwd()
     os.makedirs(FOLDER, exist_ok=True)
@@ -90,6 +103,7 @@ def createCalcPhiASEInput(
 
 ######################### parseCalcPhiASEOutput #############################
 def parseCalcPhiASEOutput(FOLDER, layout):
+    """Read ``phi_ASE``, MSE, and ray-count files from a legacy run."""
     CURRENT_DIR = os.getcwd()
     os.chdir(FOLDER)
     try:
@@ -116,6 +130,7 @@ def parseCalcPhiASEOutput(FOLDER, layout):
     return phiASE, mseValues, raysUsedPerSample
 
 def findCalcPhiASENearModule():
+    """Find the packaged ``calcPhiASE`` executable next to the Python module."""
     so_dir = Path(HASEonGPU_Bindings.__file__).resolve().parent
 
     # direct sibling
@@ -155,6 +170,13 @@ def calcPhiASEMpi(
         nPerNode,
         adaptiveSteps
 ):
+
+    """Run the legacy temporary-file path, optionally through ``mpiexec``.
+
+    This function is used by old direct ``calcPhiASE`` scripts. It serializes
+    the input arrays, launches the standalone binary, then parses the output
+    arrays back into the caller's preferred layout.
+    """
 
     minSample = 0
     nP = int(packed["numberOfPoints"])
@@ -259,6 +281,15 @@ def calcPhiASE(
         minSampleRange = 0,
         maxSampleRange = None,
 ):
+    """Run ASE using the historical direct Python signature.
+
+    ``points`` may be flat or ``(numberOfPoints, 2)``. ``trianglePointIndices``
+    may be flat or ``(numberOfTriangles, 3)``. ``betaCells`` represents
+    point-level excited-state fraction, while ``betaVolume`` represents
+    prism-centered beta used by ray tracing. The modern ``PhiASE`` wrapper
+    builds these arguments from ``GainMedium`` automatically.
+    """
+
     def transform_inputs(
             points,
             trianglePointIndices,
@@ -278,6 +309,7 @@ def calcPhiASE(
             laserParameter,
             numberOfLevels,
     ):
+        """Validate user arrays and flatten them for the pybind/backend API."""
         def is_numpy(x):
             return isinstance(x, np.ndarray)
 

--- a/pyInclude/geometry/core.py
+++ b/pyInclude/geometry/core.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Geometry, topology, and gain-medium state containers for Python users."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -25,6 +27,12 @@ except ImportError:
 
 @dataclass(frozen=True)
 class PhysicalPropertySpec:
+    """Metadata for a physical array or scalar stored on a ``GainMedium``.
+
+    ``shape`` is evaluated against the current ``MeshTopology`` so properties
+    can describe point, prism, triangle, surface, or scalar data.
+    """
+
     name: str
     dtype: object
     shape: callable
@@ -41,6 +49,12 @@ class PhysicalPropertySpec:
 
 
 class GainMediumProperty:
+    """Handle returned by ``GainMedium.get(...)``.
+
+    It carries the property's physical description, dtype, expected shape, and
+    a ``value`` setter that validates arrays before storing them on the medium.
+    """
+
     def __init__(self, medium, spec):
         self._medium = medium
         self.spec = spec
@@ -70,6 +84,7 @@ class GainMediumProperty:
         self._medium.set(self.name, values)
 
     def meta(self):
+        """Return serializable metadata for docs, inspection, or UI tooling."""
         return {
             "name": self.name,
             "description": self.description,
@@ -111,8 +126,8 @@ PHYSICAL_PROPERTY_SPECS = {
         dtype=np.float64,
         shape=_shape_prisms,
         description=(
-            "Stimulus values in each prism volume. Matrix layout is "
-            "(numberOfTriangles, numberOfLevels - 1)."
+            "Prism-centered excited-state fraction beta_j used by ASE. "
+            "Matrix layout is (numberOfTriangles, numberOfLevels - 1)."
         ),
         default=lambda topology: np.zeros(topology.numberOfPrisms, dtype=np.float64),
     ),
@@ -121,7 +136,7 @@ PHYSICAL_PROPERTY_SPECS = {
         dtype=np.float64,
         shape=_shape_cells,
         description=(
-            "Stimulus values at sample points (topology points). Matrix layout is "
+            "Point-centered excited-state fraction beta_i. Matrix layout is "
             "(numberOfPoints, numberOfLevels)."
         ),
         default=lambda topology: np.zeros(topology.numberOfPoints * topology.levels, dtype=np.float64),
@@ -130,7 +145,7 @@ PHYSICAL_PROPERTY_SPECS = {
         name="dntdAse",
         dtype=np.float64,
         shape=_shape_cells,
-        description="ASE contribution to the population derivative at sample points.",
+        description="ASE contribution to d beta / dt at sample points.",
         default=lambda topology: np.zeros(topology.numberOfPoints * topology.levels, dtype=np.float64),
     ),
     "claddingCellTypes": PhysicalPropertySpec(
@@ -170,7 +185,7 @@ PHYSICAL_PROPERTY_SPECS = {
         name="crystalTFluo",
         dtype=np.float64,
         shape=_shape_scalar,
-        description="Fluorescence lifetime of the gain medium.",
+        description="Fluorescence lifetime tau of the gain medium in seconds.",
         default=lambda _: 0.0,
     ),
     "claddingNumber": PhysicalPropertySpec(
@@ -434,6 +449,12 @@ def _flat(arr, width, dtype, name):
 
 
 class Grid:
+    """Regular rectangular helper that generates a 2D triangular base mesh.
+
+    ``xExtent`` and ``yExtent`` describe the transverse footprint. ``zExtent``
+    and ``tileSizeZ`` define the sampled crystal levels used for beta arrays.
+    """
+
     def __init__(
         self,
         xExtent=None,
@@ -445,6 +466,7 @@ class Grid:
         origin=(0.0, 0.0),
         **aliases,
     ):
+        """Create a grid from extents, tile sizes, and optional ``(x, y)`` origin."""
         if xExtent is None and "x" in aliases:
             xExtent = aliases.pop("x")
         if yExtent is None and "y" in aliases:
@@ -477,13 +499,16 @@ class Grid:
 
     @property
     def numberOfLevels(self):
+        """Number of z sample planes generated from ``zExtent`` and ``tileSizeZ``."""
         return len(self._axisValues(self.zExtent, self.tileSizeZ))
 
     @property
     def thickness(self):
+        """Distance between adjacent z levels."""
         return self.tileSizeZ
 
     def constructPoints(self):
+        """Return transverse topology points with shape ``(numberOfPoints, 2)``."""
         ox, oy = self.origin
         x_values = ox + self._axisValues(self.xExtent, self.tileSizeX)
         y_values = oy + self._axisValues(self.yExtent, self.tileSizeY)
@@ -502,19 +527,33 @@ class Grid:
 
 @dataclass
 class MeshTopology:
+    """Triangular base mesh extruded through z levels into wedge prisms.
+
+    ``points`` are transverse ``(x, y)`` coordinates. ``trianglePointIndices``
+    connect those points into the 2D base mesh. ``levels`` and ``thickness``
+    describe the z sampling used by ``betaCells`` and ``betaVolume``.
+    """
+
     points: np.ndarray
+    """Transverse coordinates with shape ``(numberOfPoints, 2)``."""
     trianglePointIndices: np.ndarray
+    """Triangle vertex indices with shape ``(numberOfTriangles, 3)``."""
     levels: int | None = None
+    """Number of z sample planes; at least two when simulation data is used."""
     thickness: float | None = None
+    """Distance between adjacent z sample planes."""
     metadata: dict = field(default_factory=dict)
+    """Importer or construction metadata kept for tooling and round-trips."""
 
     @classmethod
     def fromPoints(cls, points, numberOfLevels=None):
+        """Delaunay-triangulate transverse points into a ``MeshTopology``."""
         parsed_points, triangles = _delaunay(points)
         return cls(parsed_points, triangles, levels=numberOfLevels)
 
     @classmethod
     def fromGrid(cls, grid):
+        """Construct topology from a regular ``Grid`` helper."""
         if not isinstance(grid, Grid):
             raise TypeError("fromGrid expects a Grid instance")
         points, triangles = _grid_points_and_triangles(grid)
@@ -537,6 +576,7 @@ class MeshTopology:
 
     @classmethod
     def fromGmsh(cls, gmsh, *, numberOfLevels=None, thickness=None):
+        """Import a planar gmsh triangle mesh and attach z sampling."""
         if isinstance(gmsh, (str, Path)):
             gmsh = Gmsh.fromFile(gmsh)
         if not isinstance(gmsh, Gmsh):
@@ -545,6 +585,7 @@ class MeshTopology:
 
     @classmethod
     def fromFile(cls, filename, format=None, numberOfLevels=None, thickness=None):
+        """Load supported mesh formats: legacy VTK, planar STL, or gmsh."""
         path = Path(filename)
         mesh_format = (format or path.suffix.lstrip(".")).lower()
         if mesh_format in {"vtk", "legacy-vtk"}:
@@ -570,6 +611,7 @@ class MeshTopology:
         )
 
     def numberOfLevels(self, levels):
+        """Set the number of z sample planes and return ``self``."""
         levels = int(levels)
         if levels < 2:
             raise ValueError("numberOfLevels must be at least 2")
@@ -577,6 +619,7 @@ class MeshTopology:
         return self
 
     def withThickness(self, thickness):
+        """Set the spacing between adjacent z levels and return ``self``."""
         thickness = float(thickness)
         if thickness <= 0.0:
             raise ValueError("thickness must be positive")
@@ -584,11 +627,13 @@ class MeshTopology:
         return self
 
     def levelCoordinates(self):
+        """Return z coordinates for every level as ``0, thickness, ...``."""
         self._require_levels()
         self._require_thickness()
         return np.arange(int(self.levels), dtype=np.float64) * float(self.thickness)
 
     def pointIndexAt(self, x, y, *, tol=1e-12):
+        """Return the topology point index for a transverse coordinate."""
         query = np.asarray([x, y], dtype=np.float64)
         matches = np.flatnonzero(np.all(np.isclose(self.points, query, atol=tol, rtol=0.0), axis=1))
         if matches.size:
@@ -597,6 +642,7 @@ class MeshTopology:
         return int(np.argmin(distances))
 
     def levelIndexAt(self, z, *, tol=1e-12):
+        """Return the z-level index for a physical z coordinate."""
         levels = self.levelCoordinates()
         matches = np.flatnonzero(np.isclose(levels, float(z), atol=tol, rtol=0.0))
         if matches.size == 0:
@@ -604,6 +650,7 @@ class MeshTopology:
         return int(matches[0])
 
     def betaCellIndexAt(self, x, y, z, *, tol=1e-12, flat=False):
+        """Return the ``betaCells`` index for a physical ``(x, y, z)`` point."""
         point_index = self.pointIndexAt(x, y, tol=tol)
         level_index = self.levelIndexAt(z, tol=tol)
         if flat:
@@ -612,18 +659,22 @@ class MeshTopology:
 
     @property
     def numberOfTriangles(self):
+        """Number of base triangles, and therefore prisms per z interval."""
         return int(self.trianglePointIndices.shape[0])
 
     @property
     def numberOfPoints(self):
+        """Number of transverse sample points per z level."""
         return int(self.points.shape[0])
 
     @property
     def numberOfPrisms(self):
+        """Total number of wedge prisms in the extruded mesh."""
         self._require_levels()
         return self.numberOfTriangles * (self.levels - 1)
 
     def asGainMedium(self):
+        """Wrap this topology in an empty ``GainMedium``."""
         return GainMedium(topology=self)
 
     def _require_levels(self):
@@ -647,8 +698,17 @@ class MeshTopology:
 
 @dataclass
 class GainMedium:
+    """Mesh plus material/state properties required by ASE and pump models.
+
+    Use ``get(name)`` to inspect a property handle, including expected array
+    shape, then set ``prop.value`` or call ``set(name, value)``. Arrays may be
+    supplied in matrix shape and are stored internally in Fortran order.
+    """
+
     topology: MeshTopology
+    """Geometry and z-level sampling for this medium."""
     physical: dict = field(default_factory=dict)
+    """Canonical physical arrays and scalars stored by property name."""
 
     def __post_init__(self):
         gmsh = self.topology.metadata.get("gmsh")
@@ -659,6 +719,7 @@ class GainMedium:
 
     @classmethod
     def fromVtk(cls, filename, *, numberOfLevels=None, thickness=None):
+        """Load topology and physical fields from a legacy VTK wedge file."""
         return gainMediumFromVtk(
             filename,
             MeshTopology,
@@ -669,6 +730,7 @@ class GainMedium:
 
     @classmethod
     def fromFile(cls, filename, format=None, *, numberOfLevels=None, thickness=None):
+        """Load a gain medium; currently supports legacy VTK files."""
         path = Path(filename)
         mesh_format = (format or path.suffix.lstrip(".")).lower()
         if mesh_format in {"vtk", "legacy-vtk"}:
@@ -678,23 +740,29 @@ class GainMedium:
         )
 
     def withPhysicalProperties(self, **properties):
+        """Set several physical properties and return ``self`` for chaining."""
         for name, value in properties.items():
             self.set(name, value)
         return self
 
     def toVtk(self, filename):
+        """Write this gain medium to a legacy ASCII VTK wedge file."""
         return writeGainMediumVtk(filename, self)
 
     def emptyBetaCells(self, fill=0.0):
+        """Create a correctly shaped point-level beta array filled with ``fill``."""
         return np.full(self.get("betaCells").expectedShape, fill, dtype=np.float64)
 
     def betaCellIndexAt(self, x, y, z, *, tol=1e-12, flat=False):
+        """Forward coordinate lookup for a ``betaCells`` entry."""
         return self.topology.betaCellIndexAt(x, y, z, tol=tol, flat=flat)
 
     def listProperties(self):
+        """Return metadata for all known gain-medium properties."""
         return [self.get(name).meta() for name in PHYSICAL_PROPERTY_SPECS]
 
     def get(self, name):
+        """Return a ``GainMediumProperty`` handle by canonical name or alias."""
         canonical = PROPERTY_ALIASES.get(name, name)
         if canonical not in PHYSICAL_PROPERTY_SPECS:
             known = ", ".join(PHYSICAL_PROPERTY_SPECS)
@@ -702,6 +770,7 @@ class GainMedium:
         return GainMediumProperty(self, PHYSICAL_PROPERTY_SPECS[canonical])
 
     def set(self, name, value):
+        """Validate and store one physical property."""
         prop = self.get(name)
         if prop.expectedShape == ():
             self.physical[prop.name] = prop.dtype.type(value).item()
@@ -725,6 +794,7 @@ class GainMedium:
 
     @property
     def dntdAse(self):
+        """ASE contribution to ``d beta / dt`` at the sample points."""
         return self.get("dntdAse").value
 
     @property
@@ -741,6 +811,7 @@ class GainMedium:
 
     @property
     def numberOfLevels(self):
+        """Number of z sample planes in the attached topology."""
         self.topology._require_levels()
         return int(self.topology.levels)
 

--- a/pyInclude/geometry/msh.py
+++ b/pyInclude/geometry/msh.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""gmsh import helpers for planar triangle meshes."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -16,29 +18,48 @@ _GMSH_TRIANGLE = 2
 
 @dataclass(frozen=True)
 class GmshElement:
+    """One gmsh element with enough metadata to build topology and cladding."""
+
     element_id: int
+    """gmsh element id."""
     element_type: int
+    """gmsh element type; only triangle type 2 is imported as topology."""
     node_ids: tuple[int, ...]
+    """Node ids used by this element."""
     physical_tag: int | None = None
+    """Optional physical group tag used to infer cladding cells."""
 
 
 @dataclass
 class Gmsh:
-    """gmsh-backed mesh data accepted by MeshTopology."""
+    """gmsh-backed mesh data accepted by ``MeshTopology``.
+
+    HASEonGPU currently only accepts two-dimensional triangle meshes and
+    later extrudes them through ``numberOfLevels`` with a fixed ``thickness``.
+    Physical surface names containing ``cladding`` can populate
+    ``claddingCellTypes`` on a ``GainMedium``.
+    """
 
     nodes: dict[int, tuple[float, float, float]]
+    """Node id to ``(x, y, z)`` coordinate mapping."""
     elements: list[GmshElement]
+    """All gmsh elements read from the file."""
     physical_names: dict[int, dict[int, str]] = field(default_factory=dict)
+    """Physical names grouped by gmsh dimension and tag."""
     source: str | None = None
+    """Original gmsh filename, if loaded from disk."""
 
     @classmethod
     def fromFile(cls, filename):
+        """Read a gmsh ``.msh`` file using the gmsh Python package."""
         return _read_gmsh(filename)
 
     def topology(self, *, numberOfLevels=None, thickness=None):
+        """Convert planar triangle elements into an extruded ``MeshTopology``."""
         return _from_gmsh(self, numberOfLevels=numberOfLevels, thickness=thickness)
 
     def claddingCellTypes(self, topology):
+        """Return triangle-wise cladding tags inferred from physical names."""
         if topology.metadata.get("gmsh") is not self:
             raise ValueError("claddingCellTypes requires the MeshTopology created from this Gmsh object")
         return _gmsh_cladding_cell_types(self, topology)

--- a/pyInclude/geometry/stl.py
+++ b/pyInclude/geometry/stl.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Planar STL import helper for ``MeshTopology.fromFile``."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -44,6 +46,7 @@ def _read_stl_triangles(path):
 
 
 def from_stl(path):
+    """Return ``(points, triangles)`` from a planar ASCII or binary STL file."""
     triangles_3d = _read_stl_triangles(path)
     z = [vertex[2] for tri in triangles_3d for vertex in tri]
     if not np.allclose(z, z[0]):

--- a/pyInclude/geometry/vtk.py
+++ b/pyInclude/geometry/vtk.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Read and write legacy ASCII VTK wedge meshes for gain media."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -34,6 +36,8 @@ def _tokens(path):
 
 
 class _TokenReader:
+    """Small token stream used by the legacy VTK parser."""
+
     def __init__(self, tokens):
         self.tokens = tokens
         self.index = 0
@@ -160,6 +164,7 @@ def _topologyFromUnstructuredGrid(path):
 
 
 def topologyFromVtk(path, topologyCls):
+    """Create a ``MeshTopology`` from legacy VTK wedge cells."""
     points, triangles, levels, thickness, _ = _topologyFromUnstructuredGrid(path)
     return topologyCls(
         points=points,
@@ -171,6 +176,7 @@ def topologyFromVtk(path, topologyCls):
 
 
 def gainMediumFromVtk(path, topologyCls, gainMediumCls, *, numberOfLevels=None, thickness=None):
+    """Load topology plus beta/material arrays from a legacy VTK file."""
     topology = topologyFromVtk(path, topologyCls)
     if numberOfLevels is not None:
         topology.numberOfLevels(numberOfLevels)
@@ -184,6 +190,11 @@ def gainMediumFromVtk(path, topologyCls, gainMediumCls, *, numberOfLevels=None, 
 
 
 def writeGainMediumVtk(path, gainMedium):
+    """Write a ``GainMedium`` as legacy ASCII VTK wedge cells.
+
+    ``betaCells`` is written as point data and ``betaVolume`` as cell data;
+    scalar material properties are stored in a ``FIELD`` block.
+    """
     topology = gainMedium.topology
     topology._require_levels()
     topology._require_thickness()

--- a/pyInclude/laser.py
+++ b/pyInclude/laser.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Laser spectra and pump-beam configuration used by the Python interface."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -14,6 +16,12 @@ import numpy as np
 
 @dataclass(frozen=True)
 class LaserPropertySpec:
+    """Metadata for one low-level laser property.
+
+    The names match the historical ``calcPhiASE`` input fields. User-facing
+    code usually works through ``CrossSectionData`` or ``LaserProperties``.
+    """
+
     name: str
     dtype: object
     shape: tuple
@@ -22,6 +30,13 @@ class LaserPropertySpec:
 
 
 class LaserProperty:
+    """Handle returned by ``LaserProperties.get(...)``.
+
+    It exposes the property's physical description, expected dtype/shape, and
+    a validated ``value`` setter. The handle writes back to its parent
+    ``LaserProperties`` object.
+    """
+
     def __init__(self, laser, spec):
         self._laser = laser
         self.spec = spec
@@ -51,6 +66,7 @@ class LaserProperty:
         self._laser.set(self.name, values)
 
     def meta(self):
+        """Return serializable metadata for documentation or validation UIs."""
         return {
             "name": self.name,
             "description": self.description,
@@ -108,11 +124,24 @@ LASER_ALIASES = {
 
 @dataclass
 class CrossSectionData:
+    """Absorption and emission spectra for ASE and pump calculations.
+
+    Wavelength arrays store :math:`\lambda`; matching cross-section arrays
+    store :math:`\sigma_a` and :math:`\sigma_e` in ``cm^2``. The wavelength
+    unit is kept as supplied, with interpolation helpers handling the common
+    ``nm`` table versus ``m`` query mismatch.
+    """
+
     wavelengthsAbsorption: object
+    """Wavelength samples for the absorption spectrum."""
     crossSectionAbsorption: object
+    """Absorption cross sections :math:`\sigma_a` in ``cm^2``."""
     wavelengthsEmission: object
+    """Wavelength samples for the emission spectrum."""
     crossSectionEmission: object
+    """Emission cross sections :math:`\sigma_e` in ``cm^2``."""
     resolution: int = 1
+    """Spectral interpolation resolution passed to ``calcPhiASE``."""
 
     def __post_init__(self):
         self.wavelengthsAbsorption = np.asarray(self.wavelengthsAbsorption, dtype=np.float64).reshape(-1)
@@ -129,6 +158,7 @@ class CrossSectionData:
 
     @classmethod
     def monochromatic(cls, *, wavelength, crossSectionAbsorption, crossSectionEmission):
+        """Build a single-wavelength spectrum for monochromatic workflows."""
         return cls(
             wavelengthsAbsorption=[wavelength],
             crossSectionAbsorption=[crossSectionAbsorption],
@@ -139,6 +169,7 @@ class CrossSectionData:
 
     @classmethod
     def fromDirectory(cls, path, resolution=1000):
+        """Load ``lambda_a``, ``sigma_a``, ``lambda_e``, and ``sigma_e`` text files."""
         root = Path(path)
         return cls(
             wavelengthsAbsorption=np.loadtxt(root / "lambda_a.txt"),
@@ -149,12 +180,15 @@ class CrossSectionData:
         )
 
     def toLaserProperties(self):
+        """Wrap the same spectra in the lower-level ``LaserProperties`` store."""
         return LaserProperties(crossSections=self)
 
     def absorptionAt(self, wavelength):
+        """Interpolate :math:`\sigma_a` at ``wavelength``."""
         return self._interpolate(self.wavelengthsAbsorption, self.crossSectionAbsorption, wavelength)
 
     def emissionAt(self, wavelength):
+        """Interpolate :math:`\sigma_e` at ``wavelength``."""
         return self._interpolate(self.wavelengthsEmission, self.crossSectionEmission, wavelength)
 
     @staticmethod
@@ -177,6 +211,7 @@ class CrossSectionData:
         return float(np.interp(query, wavelengths[order], values[order]))
 
     def toDict(self):
+        """Return the dictionary layout expected by the low-level bindings."""
         return {
             "l_abs": self.wavelengthsAbsorption,
             "l_ems": self.wavelengthsEmission,
@@ -191,8 +226,17 @@ SpectralDecomposition = CrossSectionData
 
 @dataclass
 class LaserProperties:
+    """Mutable low-level laser-property store.
+
+    Prefer ``CrossSectionData`` for new simulations. This class remains useful
+    when code needs the historical ``l_abs``, ``s_abs``, ``l_ems``, ``s_ems``,
+    and ``l_res`` handles or aliases used by ``calcPhiASE``.
+    """
+
     crossSections: CrossSectionData | None = None
+    """Optional spectral data used to populate the property store."""
     values: dict = field(default_factory=dict)
+    """Canonical low-level property values."""
 
     def __post_init__(self):
         if self.crossSections is not None:
@@ -200,6 +244,7 @@ class LaserProperties:
 
     @classmethod
     def spectral(cls, **kwargs):
+        """Create ``LaserProperties`` from explicit spectral arrays."""
         if "absorption" in kwargs and "crossSectionAbsorption" not in kwargs:
             kwargs["crossSectionAbsorption"] = kwargs.pop("absorption")
         if "emission" in kwargs and "crossSectionEmission" not in kwargs:
@@ -208,6 +253,7 @@ class LaserProperties:
 
     @classmethod
     def monochromatic(cls, *, absorption, emission, wavelengthAbsorption=0.0, wavelengthEmission=0.0):
+        """Create a single-sample absorption/emission data set."""
         return cls.spectral(
             wavelengthsAbsorption=[wavelengthAbsorption],
             crossSectionAbsorption=[absorption],
@@ -218,14 +264,17 @@ class LaserProperties:
 
     @classmethod
     def fromDirectory(cls, path):
+        """Load spectral text files and wrap them as ``LaserProperties``."""
         return cls(crossSections=CrossSectionData.fromDirectory(path))
 
     def withProperties(self, **properties):
+        """Set multiple laser properties and return ``self`` for chaining."""
         for name, value in properties.items():
             self.set(name, value)
         return self
 
     def get(self, name):
+        """Return a ``LaserProperty`` handle by canonical name or alias."""
         canonical = LASER_ALIASES.get(name, name)
         if canonical not in LASER_PROPERTY_SPECS:
             known = ", ".join(LASER_PROPERTY_SPECS)
@@ -233,6 +282,7 @@ class LaserProperties:
         return LaserProperty(self, LASER_PROPERTY_SPECS[canonical])
 
     def set(self, name, value):
+        """Validate and store one laser property by canonical name or alias."""
         prop = self.get(name)
         if prop.expectedShape == ():
             self.values[prop.name] = prop.dtype.type(value).item()
@@ -246,9 +296,11 @@ class LaserProperties:
         return self
 
     def listProperties(self):
+        """Return metadata for all known laser properties."""
         return [self.get(name).meta() for name in LASER_PROPERTY_SPECS]
 
     def toDict(self):
+        """Return the complete low-level laser dictionary after validation."""
         self.validate(requiredOnly=True)
         return {
             "l_abs": self.values["l_abs"],
@@ -260,26 +312,31 @@ class LaserProperties:
 
     @property
     def maxSigmaA(self):
+        """Maximum absorption cross section :math:`\max(\sigma_a)`."""
         self.validate(requiredOnly=True)
         return float(np.max(self.values["s_abs"]))
 
     @property
     def maxSigmaE(self):
+        """Maximum emission cross section :math:`\max(\sigma_e)`."""
         self.validate(requiredOnly=True)
         return float(np.max(self.values["s_ems"]))
 
     @property
     def emissionPeakIndex(self):
+        """Index of the largest emission cross-section sample."""
         self.validate(requiredOnly=True)
         return int(np.argmax(self.values["s_ems"]))
 
     @property
     def absorptionAtEmissionPeak(self):
+        """Absorption cross section sampled at the emission peak index."""
         self.validate(requiredOnly=True)
         idx = min(self.emissionPeakIndex, len(self.values["s_abs"]) - 1)
         return float(self.values["s_abs"][idx])
 
     def validate(self, requiredOnly=False):
+        """Check required fields and matching wavelength/cross-section lengths."""
         missing = [
             name for name, spec in LASER_PROPERTY_SPECS.items()
             if spec.required and name not in self.values
@@ -303,12 +360,25 @@ class LaserProperties:
 
 @dataclass(init=False)
 class PumpProperties:
+    """Pump-beam settings used to raise the excited-state fraction ``beta``.
+
+    ``intensity`` is pump intensity :math:`I` in ``W / cm^2``. ``wavelength``
+    is the pump wavelength :math:`\lambda`. Built-in Gaussian pumping also
+    uses ``radiusX``, ``radiusY``, and ``exponent`` from ``customProperties``.
+    A custom ``solver`` may store its own knobs in the same dictionary.
+    """
+
     intensity: float
+    """Pump intensity :math:`I` in ``W / cm^2``."""
     wavelength: float | None
+    """Pump wavelength :math:`\lambda`; required for monochromatic data."""
     pumpSubsteps: int
+    """Number of time samples used by the built-in pump integrator."""
     customProperties: dict
+    """Extensible store for beam shape, reflection, spectra, and solver handles."""
 
     def __init__(self, *, intensity, pumpSubsteps=100, wavelength=None, customProperties=None, **properties):
+        """Create pump settings from core fields plus arbitrary custom properties."""
         self.intensity = float(intensity)
         self.wavelength = None if wavelength is None else float(wavelength)
         self.pumpSubsteps = int(pumpSubsteps)
@@ -342,6 +412,12 @@ class PumpProperties:
         customProperties=None,
         **extraProperties,
     ):
+        """Create settings for the built-in super-Gaussian pump profile.
+
+        The transverse profile is ``intensity * exp(-r ** exponent)`` with
+        radii ``radiusX`` and ``radiusY``. ``backReflection`` and
+        ``reflectivity`` control the backward pump pass.
+        """
         custom = dict(customProperties or {})
         custom.update(extraProperties)
         custom.update(
@@ -431,17 +507,21 @@ class PumpProperties:
         raise AttributeError(name)
 
     def withProperty(self, name, value):
+        """Set one custom pump property and return ``self``."""
         self.customProperties[name] = value
         return self
 
     def withProperties(self, **properties):
+        """Set several custom pump properties and return ``self``."""
         self.customProperties.update(properties)
         return self
 
     def getProperty(self, name, default=None):
+        """Read a custom pump property without raising ``AttributeError``."""
         return self.customProperties.get(name, default)
 
     def activeDuration(self, timeFrame):
+        """Return the pump duration used for one integration frame."""
         if self.pumpDuration is not None:
             return float(self.pumpDuration)
         if timeFrame is None:
@@ -449,12 +529,14 @@ class PumpProperties:
         return float(timeFrame)
 
     def intensityAt(self, points):
+        """Evaluate the super-Gaussian intensity profile at ``(x, y)`` points."""
         self._validateGaussianPumpParameters()
         points = np.asarray(points, dtype=np.float64)
         r = np.sqrt((points[:, 0] ** 2) / (self.radiusY ** 2) + (points[:, 1] ** 2) / (self.radiusX ** 2))
         return self.intensity * np.exp(-(r ** self.exponent))
 
     def toDict(self, timeFrame=None):
+        """Return the low-level pump dictionary consumed by ``pumping.py``."""
         self._validateGaussianPumpParameters()
         sigma_abs = self.crossSections.absorptionAt(self.wavelength)
         sigma_ems = self.crossSections.emissionAt(self.wavelength)
@@ -470,6 +552,7 @@ class PumpProperties:
         }
 
     def modeDict(self):
+        """Return low-level flags for extraction and backward reflection."""
         return {
             "BRM": int(self.backReflection),
             "R": float(self.reflectivity),

--- a/pyInclude/mpiLauncher.py
+++ b/pyInclude/mpiLauncher.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""MPI launcher support for ``PhiASE(parallelMode="mpi")``."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -24,10 +26,16 @@ from .geometry import _flat
 
 @dataclass
 class PhiAseMpiResult:
+    """Result object shaped like the direct pybind ASE result."""
+
     phiAse: np.ndarray
+    """Flattened ASE flux :math:`\Phi_i` for each beta sample."""
     mse: np.ndarray
+    """Monte Carlo mean-squared-error estimate per sample."""
     totalRays: np.ndarray
+    """Number of rays used per sample."""
     dndtAse: np.ndarray
+    """ASE contribution to ``d beta / dt`` reconstructed in Python."""
 
 
 _PROBED_MPI_IO_ROOTS: set[tuple[Path, int]] = set()
@@ -132,6 +140,12 @@ def _packedFromModernInputs(gainMedium, laser):
 
 
 def runPhiaseMPI(phiAse, gainMedium, laser, laserProperties):
+    """Run ``calcPhiASE`` through ``mpiexec`` and return arrays to Python.
+
+    The launcher writes temporary input files below ``IO/phiase_mpi`` so every
+    MPI rank can see the same directory, then reads the output files back into
+    a ``PhiAseMpiResult``.
+    """
     packed = _packedFromModernInputs(gainMedium, laser)
     topology = gainMedium.topology
     min_sample = 0 if phiAse.minSampleRange is None else int(phiAse.minSampleRange)

--- a/pyInclude/pumping.py
+++ b/pyInclude/pumping.py
@@ -29,6 +29,13 @@
 # spatial), informations about the intensity filed (pump or pulse) and the
 # doping-gradient (given externally)
 
+"""Pump integration routines for evolving the excited-state fraction beta.
+
+The public entry point is ``integrateLaserPump``. The lower functions are the
+legacy beta-int3 algorithm, kept as implementation detail and accelerated with
+numba when available.
+"""
+
 import numpy as np
 try:
     from numba import njit
@@ -59,6 +66,8 @@ CONSTANT_ALIASES = {
 
 
 class Constants:
+     """Physical constants used by the pump energy-to-photon conversion."""
+
      def __init__(
           self,
           speedOfLight=CONSTANT_SPECS["speedOfLight"]["default"],
@@ -67,6 +76,7 @@ class Constants:
           c=None,
           h=None,
      ):
+          """Create constants, accepting either long names or ``c``/``h`` aliases."""
           if c is not None:
                speedOfLight = c
           if h is not None:
@@ -91,6 +101,7 @@ class Constants:
           self.planckConstant = float(value)
 
      def describeConstant(self, name):
+          """Return description, unit, and default for a known constant."""
           canonical = CONSTANT_ALIASES.get(name, name)
           try:
                return dict(CONSTANT_SPECS[canonical])
@@ -99,6 +110,7 @@ class Constants:
                raise KeyError(f"unknown physical constant '{name}'. Known constants: {known}") from exc
 
      def toDict(self):
+          """Return the compact dictionary consumed by the legacy pump kernel."""
           return {
               "c": float(self.speedOfLight),
               "h": float(self.planckConstant),
@@ -106,15 +118,14 @@ class Constants:
 
 
 def _constantsDict(constants):
+     """Normalize ``None``, ``Constants``, or mapping constants to a dictionary."""
      if constants is None:
           return Constants().toDict()
      if isinstance(constants, Constants):
           return constants.toDict()
      return constants
 
-"""
-    Just in time compilation of the hot loop (over time and pumping steps) using scratch memory arrays
-"""
+# Numba-compiled hot loop over time samples and crystal z steps.
 @njit(cache=True, fastmath=True)
 def beta_int3Kernel_jit(
           beta_crystal, pulse, beta_store, Ntot_gradient,
@@ -125,6 +136,7 @@ def beta_int3Kernel_jit(
           inv_photon_energy, inv_tau_fluo,
           extr, brm, R
 ):
+      """Propagate pump intensity and update beta along one crystal line."""
       # discretization
       steps_time = pulse.shape[0]
       steps_crystal = beta_crystal.shape[0]
@@ -186,9 +198,6 @@ def beta_int3Kernel_jit(
           #     if icrys or jcrys makes no difference
           for k in range(steps_crystal):
               beta_store[k, itime] = beta_crystal[k]
-"""
-    Runs the outer loop over all sample points.
-"""
 def beta_int3LoopOverPoints(
           p, beta_cell, pump_dict, intensity, beta_c_2,
           beta_crystal_scratch, pulse_scratch, beta_store_scratch,
@@ -202,6 +211,11 @@ def beta_int3LoopOverPoints(
           pump_scratch, pump_brm_scratch, pump_l_scratch,
           debug=False
 ):
+    """Run the one-dimensional pump kernel for every transverse mesh point.
+
+    The super-Gaussian factor turns the global pump intensity into a local
+    intensity for each ``(x, y)`` sample before z propagation starts.
+    """
     rx = float(pump_dict['rx'])
     ry = float(pump_dict['ry'])
     exp_ = float(pump_dict['exp'])
@@ -234,11 +248,13 @@ def beta_int3LoopOverPoints(
 
           # write back result for this point
           beta_c_2[i_p, :] = beta_crystal_scratch
-"""
-    Runs the beta-pumping step for each point.
-    This function acts as a hub that initializes constants and fields (once) and setup scratch pad memory arrays.
-"""
 def beta_int3Main(p, beta_cell, pump, beta_c_2, intensity, const, crystal, steps, int_field, mode, Ntot_gradient):
+     """Run one pump update over all transverse points and z levels.
+
+     ``beta_cell`` is the incoming point-level beta array. ``beta_c_2`` receives
+     the beta state after pumping. Scratch arrays are allocated once here and
+     reused by the inner loops for performance.
+     """
      # discretization
      steps_time = int(steps['time'])
      steps_crystal = int(steps['crys'])
@@ -320,6 +336,12 @@ def integrateLaserPump(
      constants=None,
      pumpSubsteps=100,
 ):
+     """Return ``betaCells`` after applying the configured pump.
+
+     ``points`` are transverse ``(x, y)`` topology coordinates. ``betaCells``
+     has shape ``(numberOfPoints, numberOfLevels)`` and stores the excited-state
+     fraction before pumping. The returned array has the same shape.
+     """
      constants = _constantsDict(constants)
      topology = gainMedium.topology
      beta_cells = np.ascontiguousarray(np.asarray(betaCells, dtype=np.float64))
@@ -358,7 +380,10 @@ runLaserPumpStep = integrateLaserPump
 
 
 class BetaIntegrationGaussianSolver:
+     """Default ``PumpProperties`` solver for a super-Gaussian pump beam."""
+
      def step(self, input, pump):
+          """Return beta after pumping using the Simulation pump-solver protocol."""
           medium = input["_medium"]
           timeStep = input["_timeStep"]
           return integrateLaserPump(

--- a/pyInclude/simulation.py
+++ b/pyInclude/simulation.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""High-level Python simulation wrapper around pump, ASE, and time stepping."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -20,6 +22,11 @@ from .timeIntegration import TimeDerivative, TimeIntegrationSolver
 
 
 def _constructHostMesh(gainMedium):
+    """Build the pybind host mesh from a ``GainMedium``.
+
+    Arrays are flattened in Fortran order because the lower-level C++/legacy
+    interfaces index beta first by transverse sample and then by z level.
+    """
     topology = gainMedium.topology
     topology._require_levels()
     if topology.thickness is None:
@@ -61,28 +68,55 @@ def _constructHostMesh(gainMedium):
 
 @dataclass
 class PhiASE:
+    """Configure and run the ASE flux calculation for one gain-medium state.
+
+    ``Simulation`` normally owns this object and calls ``run(...)`` during each
+    time-step derivative evaluation. Advanced users can also call ``run``
+    directly with a ``GainMedium`` and ``CrossSectionData`` object.
+    """
+
     config: object | None = None
+    """Optional YAML filename or mapping with PhiASE run-control settings."""
     crossSections: CrossSectionData | None = None
+    """Absorption/emission spectra used by the ASE calculation."""
     spectralProperties: SpectralDecomposition | None = None
+    """Alias for ``crossSections`` kept for the public spectral API."""
     laserProperties: LaserProperties | None = None
+    """Lower-level laser property store accepted by legacy workflows."""
     gainMedium: GainMedium | None = None
+    """Optional medium stored for direct ``run()`` calls."""
 
     minRaysPerSample: int = 100000
+    """Minimum Monte Carlo rays launched for each beta sample."""
     maxRaysPerSample: int = 100000
+    """Maximum rays per sample allowed during adaptive refinement."""
     mseThreshold: float = 0.1
+    """Target mean-squared-error threshold for adaptive ASE sampling."""
     repetitions: int = 4
+    """Maximum repeated ASE estimates at a fixed ray count."""
     adaptiveSteps: int = 4
+    """Number of ray-count increases between min and max rays."""
     useReflections: bool = True
+    """Whether top/bottom surface reflectivities affect ray propagation."""
     monochromatic: bool = False
+    """Use only the first spectral samples instead of wavelength integration."""
 
     backend: str = None
+    """Alpaka backend name; inspect valid strings with ``AlpakaBackends.all()``."""
     parallelMode: str = "single"
+    """Execution mode: direct binding ``single`` or MPI launcher ``mpi``."""
     numDevices: int = 1
+    """Maximum compute devices made available to the lower-level run."""
     nPerNode: int = 1
+    """MPI launcher ranks per node when ``parallelMode`` is ``mpi``."""
     writeVtk: bool = False
+    """Request VTK output from lower-level compute paths when supported."""
     devices: list[int] = field(default_factory=list)
+    """Optional explicit device ids passed to the lower-level compute path."""
     minSampleRange: int | None = None
+    """Inclusive first flattened beta sample processed by ASE."""
     maxSampleRange: int | None = None
+    """Inclusive last flattened beta sample processed by ASE."""
 
     _experiment: object | None = field(default=None, init=False, repr=False)
     _compute: object | None = field(default=None, init=False, repr=False)
@@ -116,6 +150,7 @@ class PhiASE:
 
     @classmethod
     def fromYaml(cls, filename, **overrides):
+        """Create a ``PhiASE`` configuration from YAML plus Python overrides."""
         obj = cls(filename)
         for name, value in overrides.items():
             setattr(obj, name, value)
@@ -123,6 +158,7 @@ class PhiASE:
 
     @staticmethod
     def addArguments(parser):
+        """Add command-line arguments that map to ``PhiASE`` settings."""
         parser.add_argument("--phi-ase-config", default=None, help="YAML file with PhiASE compute/experiment settings")
         parser.add_argument("--min-rays-per-sample", type=int, default=None)
         parser.add_argument("--max-rays-per-sample", type=int, default=None)
@@ -137,6 +173,7 @@ class PhiASE:
 
     @classmethod
     def fromArgs(cls, args, **overrides):
+        """Create a ``PhiASE`` configuration from parsed argparse results."""
         config = getattr(args, "phi_ase_config", None)
         obj = cls(config) if config else cls()
         mapping = {
@@ -206,6 +243,11 @@ class PhiASE:
         return self
 
     def run(self, gainMedium=None, crossSections=None):
+        """Run ASE for the supplied or configured ``GainMedium``.
+
+        Returns ``self``. Use ``getResults()`` afterwards to access the raw
+        lower-level result, including ``phiAse``.
+        """
         medium = gainMedium if gainMedium is not None else self.gainMedium
         if medium is None:
             raise ValueError("PhiASE.run requires gainMedium; pass it through Simulation or run(gainMedium=...)")
@@ -262,27 +304,40 @@ class PhiASE:
         return self
 
     def getResults(self):
+        """Return the raw ASE result from the most recent ``run(...)`` call."""
         if self._result is None:
             raise RuntimeError("simulation has not been run yet")
         return self._result
 
     @property
     def experimentParameters(self):
+        """Low-level experiment parameters built for the last ``run(...)``."""
         return self._experiment
 
     @property
     def computeParameters(self):
+        """Low-level compute parameters built for the last ``run(...)``."""
         return self._compute
 
     @property
     def hostMesh(self):
+        """Low-level host mesh built from the last ``GainMedium`` input."""
         return self._hostMesh
 
+
 class LegacyGridDataBetaVolumeMapper:
+    """Map point-centered ``betaCells`` to prism-centered ``betaVolume``."""
+
     def __init__(self, method="linear"):
+        """Create a mapper using a scipy ``griddata`` interpolation method.
+
+        The mapper samples point-level beta values at prism centers so ASE can
+        use one representative excited-state fraction per wedge volume.
+        """
         self.method = method
 
     def map(self, medium):
+        """Return prism-centered ``betaVolume`` for the supplied medium."""
         try:
             from scipy.interpolate import griddata
         except ImportError as exc:
@@ -320,27 +375,60 @@ class LegacyGridDataBetaVolumeMapper:
 
 @dataclass
 class TimeStepState:
+    """Snapshot handed to ``onStep`` callbacks after a completed time step.
+
+    The arrays are copies of the simulation outputs at ``step``/``time``.
+    ``betaCells`` and ``phiAse`` are point-by-level arrays with shape
+    ``(numberOfPoints, numberOfLevels)``. ``betaVolume`` is prism-centered
+    with shape ``(numberOfTriangles, numberOfLevels - 1)``.
+    """
+
     step: int
+    """Completed one-based step index."""
     time: float
+    """Physical simulation time after the step, in seconds."""
     betaCells: np.ndarray
+    """Excited-state fraction at mesh points and z-levels."""
     betaVolume: np.ndarray
+    """Excited-state fraction interpolated to wedge-prism centers."""
     phiAse: np.ndarray | None
+    """ASE flux at mesh points and z-levels, or ``None`` if unavailable."""
     dndtAse: np.ndarray
+    """ASE depletion contribution to ``d beta / dt``."""
     dndtPump: np.ndarray
+    """Pump contribution to ``d beta / dt``."""
     aseResult: object | None
+    """Raw lower-level ASE result object for advanced inspection."""
 
 
 @dataclass
 class Simulation:
+    """High-level pump, ASE, fluorescence, and time-integration loop.
+
+    Register ``onInit`` or ``beforeStep`` callbacks when a function needs the
+    live ``Simulation`` object and may inspect or mutate it. Register
+    ``onStep`` callbacks when a function needs the completed ``TimeStepState``
+    snapshot produced by each step.
+    """
+
     gainMedium: GainMedium
+    """Geometry, material data, and current beta arrays."""
     pump: PumpProperties
+    """Pump model that adds population to ``betaCells``."""
     phiASE: PhiASE
+    """ASE configuration and execution handle."""
     timeIntegrationSolver: TimeIntegrationSolver
+    """Solver object that advances ``betaCells`` using ``d beta / dt``."""
     timeStep: float
+    """Physical time increment per step, in seconds."""
     crossSections: CrossSectionData | None = None
+    """Shared spectra used by pump and ASE when not set on either object."""
     endTime: float | None = None
+    """Optional target physical time for ``runUntil()``."""
     constants: Constants = field(default_factory=Constants)
+    """Physical constants used by the pump integrator."""
     updateTerminalLevel: bool = True
+    """Whether the last z-level beta values are advanced by the solver."""
 
     _time: float = field(default=0.0, init=False, repr=False)
     _step: int = field(default=0, init=False, repr=False)
@@ -375,18 +463,37 @@ class Simulation:
         raise ValueError("Simulation requires spectral properties via Simulation.crossSections, phiASE, or pump")
 
     def onStep(self, callback):
+        """Register ``callback(state)`` to run after every completed step.
+
+        ``state`` is a ``TimeStepState`` containing copied result arrays such as
+        ``betaCells``, ``betaVolume``, ``phiAse``, ``dndtPump``, and
+        ``dndtAse``. Callback return values are ignored.
+        """
         self._callbacks.append(callback)
         return self
 
     def onInit(self, callback):
+        """Register ``callback(simulation)`` to run once before the first step.
+
+        The callback receives this live ``Simulation`` object, so it can read
+        or change ``gainMedium``, ``pump``, ``phiASE``, ``timeStep``, and other
+        simulation settings before any derivative is evaluated.
+        """
         self._initCallbacks.append(callback)
         return self
 
     def beforeStep(self, callback):
+        """Register ``callback(simulation)`` to run before every step.
+
+        The callback receives this live ``Simulation`` object at the current
+        ``time`` and ``stepIndex``. Use this for controlled changes to inputs
+        before the next time-step update.
+        """
         self._beforeStepCallbacks.append(callback)
         return self
 
     def runUntil(self, endtime=None, endTime=None):
+        """Advance steps until the configured or supplied end time is reached."""
         target = self.endTime if endtime is None and endTime is None else (endtime if endtime is not None else endTime)
         if target is None:
             raise ValueError("runUntil requires endtime or an endTime configured on construction")
@@ -395,11 +502,13 @@ class Simulation:
         return self
 
     def runSteps(self, steps):
+        """Run exactly ``steps`` calls to ``step()`` and return ``self``."""
         for _ in range(int(steps)):
             self.step()
         return self
 
     def step(self):
+        """Advance one time step and return the completed ``TimeStepState``."""
         self._runInitCallbacks()
         for callback in self._beforeStepCallbacks:
             callback(self)
@@ -449,14 +558,17 @@ class Simulation:
         return state
 
     def getResults(self):
+        """Return all stored ``TimeStepState`` snapshots in step order."""
         return self._states
 
     @property
     def time(self):
+        """Current physical simulation time in seconds."""
         return self._time
 
     @property
     def stepIndex(self):
+        """Number of completed time steps."""
         return self._step
 
     def _ensureStateArrays(self):

--- a/pyInclude/timeIntegration.py
+++ b/pyInclude/timeIntegration.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Time-integration solvers for the point-level beta population arrays."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -13,29 +15,61 @@ import numpy as np
 
 @dataclass(frozen=True)
 class TimeDerivative:
+    """Derivative evaluation produced during one time-integration stage.
+
+    ``Simulation`` builds this object from pump gain, ASE depletion, and
+    fluorescence decay. Custom solvers receive it from their ``rhs`` callback
+    while trying candidate ``betaCells`` values.
+    """
+
     betaCells: np.ndarray
+    """Point-level excited-state fraction used for this RHS evaluation."""
     dndtPump: np.ndarray
+    """Pump source contribution to ``d beta / dt`` in ``1 / s``."""
     dndtAse: np.ndarray
+    """ASE depletion contribution to ``d beta / dt`` in ``1 / s``."""
     derivative: np.ndarray
+    """Total ``d beta / dt`` advanced by the time solver."""
     tau: float
+    """Fluorescence lifetime used for spontaneous decay, in seconds."""
     phiAse: np.ndarray | None = None
+    """ASE flux :math:`\Phi_i` from the derivative evaluation, if available."""
     aseResult: object | None = None
+    """Raw lower-level ASE result object, if available."""
 
 
 @dataclass(frozen=True)
 class TimeIntegrationResult:
+    """Return object from ``TimeIntegrationSolver.step(...)``."""
+
     betaCells: np.ndarray
+    """Updated point-level beta array proposed by the solver."""
     evaluation: TimeDerivative
+    """Derivative evaluation to expose in the resulting ``TimeStepState``."""
 
 
 class TimeIntegrationSolver:
+    """Base protocol for custom beta time-integration solvers.
+
+    Implement ``step(rhs, betaCells, time, timeStep)``. ``rhs`` is a callable
+    that accepts ``(betaCells, time)`` and returns a ``TimeDerivative``. Higher
+    order solvers may call ``rhs`` several times for one public simulation step.
+    """
+
     name = "base"
 
     def step(self, rhs, betaCells, time, timeStep):
+        """Return a ``TimeIntegrationResult`` for one physical time step.
+
+        ``time`` and ``timeStep`` are in seconds. ``betaCells`` has the same
+        shape as ``GainMedium.get("betaCells").expectedShape``.
+        """
         raise NotImplementedError
 
 
 class ExplicitEuler(TimeIntegrationSolver):
+    """First-order explicit Euler beta update using one RHS evaluation."""
+
     name = "explicit-euler"
 
     def step(self, rhs, betaCells, time, timeStep):
@@ -44,6 +78,8 @@ class ExplicitEuler(TimeIntegrationSolver):
 
 
 class Heun(TimeIntegrationSolver):
+    """Second-order predictor-corrector beta update using two RHS evaluations."""
+
     name = "heun"
 
     def step(self, rhs, betaCells, time, timeStep):
@@ -54,6 +90,8 @@ class Heun(TimeIntegrationSolver):
 
 
 class Midpoint(TimeIntegrationSolver):
+    """Second-order midpoint beta update using a half-step RHS evaluation."""
+
     name = "midpoint"
 
     def step(self, rhs, betaCells, time, timeStep):
@@ -63,6 +101,8 @@ class Midpoint(TimeIntegrationSolver):
 
 
 class RungeKutta4(TimeIntegrationSolver):
+    """Classical fourth-order Runge-Kutta beta update using four RHS evaluations."""
+
     name = "runge-kutta-4"
 
     def step(self, rhs, betaCells, time, timeStep):
@@ -77,9 +117,12 @@ class RungeKutta4(TimeIntegrationSolver):
 
 
 class ImplicitEuler(TimeIntegrationSolver):
+    """Fixed-point implicit Euler beta update for stiff beta dynamics."""
+
     name = "implicit-euler"
 
     def __init__(self, iterations=8, tolerance=1e-10):
+        """Set maximum fixed-point iterations and infinity-norm tolerance."""
         self.iterations = int(iterations)
         self.tolerance = float(tolerance)
 
@@ -96,6 +139,8 @@ class ImplicitEuler(TimeIntegrationSolver):
 
 
 class ExponentialEuler(TimeIntegrationSolver):
+    """Euler source update with analytical fluorescence decay over ``timeStep``."""
+
     name = "exponential-euler"
 
     def step(self, rhs, betaCells, time, timeStep):

--- a/pyInclude/vtkWedge.py
+++ b/pyInclude/vtkWedge.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Legacy ASCII VTK writer for wedge-prism HASEonGPU data."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -14,6 +16,7 @@ from .geometry import GainMedium, MeshTopology
 
 
 def _topology_from_geometry(geometry):
+    """Extract ``MeshTopology`` from a topology or owning ``GainMedium``."""
     if isinstance(geometry, GainMedium):
         return geometry.topology
     if isinstance(geometry, MeshTopology):
@@ -22,6 +25,7 @@ def _topology_from_geometry(geometry):
 
 
 def _vtk_filename(file_name, state=None, field="phiAse"):
+    """Resolve ``{step}``, ``{time}``, and ``{field}`` filename placeholders."""
     text = str(file_name)
     if state is not None:
         text = text.format(
@@ -35,6 +39,7 @@ def _vtk_filename(file_name, state=None, field="phiAse"):
 
 
 def _as_named_array(data, field, scalar_name):
+    """Select a named scalar array from a state object or raw array."""
     if hasattr(data, field):
         values = getattr(data, field)
         name = scalar_name or field
@@ -47,6 +52,7 @@ def _as_named_array(data, field, scalar_name):
 
 
 def _resolve_data_shape(values, topology):
+    """Classify arrays as point-level or prism-level VTK scalar data."""
     point_shape = (topology.numberOfPoints, int(topology.levels))
     cell_shape = (topology.numberOfTriangles, int(topology.levels) - 1)
     if values.shape == point_shape:
@@ -64,6 +70,7 @@ def _resolve_data_shape(values, topology):
 
 
 def _write_ascii_wedge(file_name, values, topology, scalar_name="scalars"):
+    """Write scalar data on the topology's extruded wedge-prism mesh."""
     topology._require_levels()
     topology._require_thickness()
 
@@ -117,6 +124,7 @@ def _write_ascii_wedge(file_name, values, topology, scalar_name="scalars"):
 
 
 def _legacy_vtk_wedge(file_name, values, points, triangle_point_indices, mesh_z, z_mesh, scalar_name):
+    """Compatibility wrapper for the historical points/triangles signature."""
     topology = MeshTopology(
         points=np.asarray(points, dtype=np.float64),
         trianglePointIndices=np.asarray(triangle_point_indices, dtype=np.uint32),
@@ -127,8 +135,17 @@ def _legacy_vtk_wedge(file_name, values, points, triangle_point_indices, mesh_z,
 
 
 def vtkWedge(file_name, data=None, geometry=None, field="phiAse", scalar_name=None, every=1):
-    """
-        Write HASEonGPU wedge data to a legacy ASCII VTK file.
+    """Write HASEonGPU wedge data to a ASCII VTK file.
+
+    Direct use: pass ``data`` as a ``TimeStepState`` or array and ``geometry``
+    as a ``GainMedium`` or ``MeshTopology``. Callback use: pass the geometry as
+    ``data`` and omit ``geometry``; the returned ``write_state(state)`` function
+    can be registered with ``Simulation.onStep(...)``.
+
+    Point-shaped arrays ``(numberOfPoints, levels)`` become ``POINT_DATA``;
+    prism-shaped arrays ``(numberOfTriangles, levels - 1)`` become
+    ``CELL_DATA``. ``file_name`` may contain ``{step}``, ``{time}``, and
+    ``{field}`` placeholders when used as an ``onStep`` callback.
     """
 
     if isinstance(data, (GainMedium, MeshTopology)) and geometry is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,15 @@ dependencies=[
 build-dir = "build/{wheel_tag}"
 wheel.packages = ["HASEonGPU_Bindings", "pyInclude"]
 
+[[tool.scikit-build.generate]]
+path = "HASEonGPU.py"
+template = """
+import HASEonGPU_Bindings
+from HASEonGPU_Bindings import *
+from pyInclude import *
+del HASEonGPU_Bindings.HostMesh
+"""
+
 [tool.scikit-build.cmake]
 build-type = "Release"
 [tool.scikit-build.cmake.define]

--- a/tests/python/gainMedium/test_gainMedium.py
+++ b/tests/python/gainMedium/test_gainMedium.py
@@ -118,7 +118,6 @@ def testGainMediumPhysicalPropertiesAreDiscoverableAndAssignable():
 
     assert betaVolume.expectedShape == (2, 8)
     assert betaVolume.dtype == np.dtype(np.float64)
-    assert "prism volume" in betaVolume.description
     assert refractiveIndices.name == "refractiveIndices"
     assert refractiveIndices.expectedShape == (4,)
 


### PR DESCRIPTION
In the previous alpaka merge, the documentation build failed due to using the wrong Python version and pyInclude not being installed as a wheel.

Additionally, autosummary did not provide any useful information, since the Python interface lacked clear documentation for user-facing methods and objects.