### PR TITLE
add a small nudge factor to mitigate triangle intersection hits

### DIFF
--- a/src/kernels/propagateRay.cpp
+++ b/src/kernels/propagateRay.cpp
@@ -241,6 +241,9 @@ namespace hase::kernels
         double gain = 1;
         int nextForbiddenEdge = -1;
         int nextEdge = -1;
+        // applies a small epsilon to "nudge" the ray along its trajectory in case we hit exactly on a triangle/surface
+        // intersection
+        constexpr double boundaryNudgeFactor = 64.0 * 2.2204460492503131e-16;
 
         // Length to small, could be same points
         if(distanceTotal < SMALL)
@@ -265,6 +268,14 @@ namespace hase::kernels
             if(nextEdge != -1)
             {
                 updateFromEdge(nextTriangle, &nextForbiddenEdge, nextLevel, mesh, nextEdge);
+
+                double const boundaryNudge = boundaryNudgeFactor * distanceTotal;
+                static_assert(SMALL > boundaryNudgeFactor);
+                if(length < boundaryNudge && distanceRemaining > boundaryNudge)
+                {
+                    nextRay = calcNextRay(nextRay, boundaryNudge);
+                    distanceRemaining -= boundaryNudge;
+                }
             }
         }
 

--- a/tests/python/phiAse/test_analyticalSphere.py
+++ b/tests/python/phiAse/test_analyticalSphere.py
@@ -124,8 +124,8 @@ sigmaA = np.float64(0.11e-20)
 sigmaE = np.float64(2.1e-20)
 sphereCases = [
     (np.float64(radiusValue), np.float64(g0Value / 100))
-    for radiusValue in np.geomspace(0.1, 100, num=9)
-    for g0Value in np.geomspace(5, 400, num=9)
+    for radiusValue in np.geomspace(0.1, 100, num=8)
+    for g0Value in np.geomspace(5, 400, num=8)
     if 5.0 >= np.float64(radiusValue) * np.float64(g0Value / 100) >= 1.0 >= calcBetaFromGain(g0Value/ 100, nTot, sigmaA, sigmaE) >= 0.0
 ]
 


### PR DESCRIPTION
This PR adresses #157 by introducing a small nudge factor that is relative to the total ray distance. In cases where no progress is made because of the ray exactly hitting a triangle or surface intersection a small  nudge factor is applied which pushes the ray forward along its trajectory.