### PR TITLE
Use double precision for ray length

### DIFF
--- a/include/core/geometry.hpp
+++ b/include/core/geometry.hpp
@@ -58,7 +58,7 @@ namespace hase::core
     {
         Point p;
         Vector dir;
-        float length;
+        double length;
     };
 
     struct NormalRay
@@ -74,7 +74,7 @@ namespace hase::core
     };
 
     ALPAKA_FN_HOST_ACC Vector direction(Point startPoint, Point endPoint);
-    ALPAKA_FN_HOST_ACC float distance(Point startPoint, Point endPoint);
+    ALPAKA_FN_HOST_ACC double distance(Point startPoint, Point endPoint);
     ALPAKA_FN_HOST_ACC Ray generateRay(Point startPoint, Point endPoint);
     ALPAKA_FN_HOST_ACC Ray normalizeRay(Ray ray);
 

--- a/include/kernels/detail/importanceSampling.hpp
+++ b/include/kernels/detail/importanceSampling.hpp
@@ -213,10 +213,8 @@ namespace hase::kernels
                     alpaka::onAcc::worker::threadsInGrid,
                     alpaka::IdxRange{hase::alpakaUtils::Vec1D{raysPerSample}}))
             {
-                double const draw = alpaka::rand::distribution::UniformReal{
-                    0.0f,
-                    static_cast<float>(sumPhi),
-                    alpaka::rand::interval::co}(engine);
+                double const draw
+                    = alpaka::rand::distribution::UniformReal<double>{0.0, sumPhi, alpaka::rand::interval::co}(engine);
 
                 unsigned lower = 0u;
                 unsigned upper = numberOfWeightedPrisms;
@@ -234,8 +232,12 @@ namespace hase::kernels
                     }
                 }
 
-                if(lower < numberOfWeightedPrisms)
+                if(numberOfWeightedPrisms > 0u)
                 {
+                    if(lower >= numberOfWeightedPrisms)
+                    {
+                        lower = numberOfWeightedPrisms - 1u;
+                    }
                     alpaka::onAcc::atomicAdd(acc, &raysPerPrism[lower], 1u);
                 }
             }

--- a/src/core/geometry.cpp
+++ b/src/core/geometry.cpp
@@ -31,13 +31,13 @@ namespace hase::core
         return v;
     }
 
-    ALPAKA_FN_HOST_ACC float distance(Point startPoint, Point endPoint)
+    ALPAKA_FN_HOST_ACC double distance(Point startPoint, Point endPoint)
     {
-        float x, y, z;
+        double x, y, z;
         x = endPoint.x - startPoint.x;
         y = endPoint.y - startPoint.y;
         z = endPoint.z - startPoint.z;
-        float d = alpaka::math::sqrt(x * x + y * y + z * z);
+        double d = alpaka::math::sqrt(x * x + y * y + z * z);
         return alpaka::math::abs(d);
     }
 

--- a/src/kernels/propagateRay.cpp
+++ b/src/kernels/propagateRay.cpp
@@ -240,10 +240,10 @@ namespace hase::kernels
         double length = 0;
         double gain = 1;
         int nextForbiddenEdge = -1;
-        int nextEdge = -1;
         // applies a small epsilon to "nudge" the ray along its trajectory in case we hit exactly on a triangle/surface
         // intersection
-        constexpr double boundaryNudgeFactor = 64.0 * 2.2204460492503131e-16;
+        constexpr double numberOfEpsShifts = 64.0; // small eps factor
+        constexpr double boundaryNudgeFactor = numberOfEpsShifts * std::numeric_limits<double>::epsilon();
 
         // Length to small, could be same points
         if(distanceTotal < SMALL)
@@ -255,7 +255,7 @@ namespace hase::kernels
             assert(*nextLevel <= mesh.numberOfLevels);
             // Calc gain for triangle intersection
             length = distanceRemaining;
-            nextEdge
+            int const nextEdge
                 = calcTriangleRayIntersection(&length, *nextTriangle, nextRay, *nextLevel, nextForbiddenEdge, mesh);
             nextRay = calcNextRay(nextRay, length);
             double gainTmp = calcPrismGain(*nextTriangle, *nextLevel, length, mesh, sigmaA, sigmaE);

--- a/tests/interpolation.cpp
+++ b/tests/interpolation.cpp
@@ -30,7 +30,7 @@ std::vector<double> makeSortedUniqueX(std::size_t n, uint32_t seed)
     for(std::size_t i = 1; i < x.size(); ++i)
     {
         if(x[i] <= x[i - 1])
-            x[i] = std::nextafter(x[i - 1], std::numeric_limits<double>::infinity());
+            x[i] = std::nextafter(x[i - 1], std::numeric_limits<double>::max());
     }
     return x;
 }


### PR DESCRIPTION
This PR addresses #160 by storing `Ray::length` in double precision.

  `Ray` already stores six double-precision coordinate values, so the previous single-precision length was
  likely padded in memory anyway. This mitigates near-zero ray length instability, but does not fully
  eliminate the underlying singular edge case.