### PR TITLE
fix off-by one error for mesh z-level pumping

### DIFF
--- a/docs/source/python_interface/simulation.rst
+++ b/docs/source/python_interface/simulation.rst
@@ -198,10 +198,3 @@ Beta Volume Mapping
 (:math:`\beta_i`) after each step using ``LegacyGridDataBetaVolumeMapper``.
 The mapper interpolates beta values from topology points and z-levels to prism
 centers.  It requires ``scipy``.
-
-``updateTerminalLevel``
------------------------
-
-By default ``updateTerminalLevel=True`` and every z-level is updated.  If it is
-set to ``False``, the terminal level is preserved while the other levels are
-advanced.

--- a/example/python_example/laserPumpCladding.py
+++ b/example/python_example/laserPumpCladding.py
@@ -174,7 +174,6 @@ def runExample(
         timeStep=2e-5, #20 μs
         crossSections=spectralProperties,
         constants=Constants(c=3e8, h=6.626e-34), ## these constants match legacy skript values
-        updateTerminalLevel=False,
         enableAse=enableAse,
     )
     simulation.onInit(prePumpInitialState)

--- a/example/python_example/laserPumpCladdingOldPump.py
+++ b/example/python_example/laserPumpCladdingOldPump.py
@@ -178,7 +178,6 @@ def runExample(
         timeStep=2e-5, #20 μs
         crossSections=spectralProperties,
         constants=Constants(c=3e8, h=6.626e-34), ## these constants match legacy skript values
-        updateTerminalLevel=False,
         enableAse=enableAse,
     )
     simulation.onInit(prePumpInitialState)

--- a/example/python_example/legacy/laserPumpCladdingExample.py
+++ b/example/python_example/legacy/laserPumpCladdingExample.py
@@ -415,7 +415,7 @@ def main(
 
         # Now for the cladding points
         for i_p in range(length_clad):
-            for i_z in range(mesh_z-1):
+            for i_z in range(mesh_z):
                 # Calc local gain (g_l)
                 pos_clad = clad_points_t[i_p]
                 flux_clad[pos_clad,i_z] = clad_abs*phi_ASE[pos_clad,i_z]
@@ -466,7 +466,7 @@ def main(
         one_minus = (1.0 - exp_fac)
 
         for i_p in range(p.shape[0]):
-            for i_z in range(mesh_z - 1):
+            for i_z in range(mesh_z):
                 beta_cell[i_p, i_z] = (
                         tfluo * (dndt_pump[i_p, i_z] - dndt_ASE[i_p, i_z]) * one_minus
                         + beta_cell[i_p, i_z] * exp_fac

--- a/pyInclude/simulation.py
+++ b/pyInclude/simulation.py
@@ -434,8 +434,6 @@ class Simulation:
     """Optional target physical time for ``runUntil()``."""
     constants: Constants = field(default_factory=Constants)
     """Physical constants used by the pump integrator."""
-    updateTerminalLevel: bool = True
-    """Whether the last z-level beta values are advanced by the solver."""
     enableAse: bool = True
     """Whether each derivative evaluation runs ASE depletion through ``PhiASE``."""
 
@@ -580,10 +578,7 @@ class Simulation:
         updated_beta = integration_result.betaCells
         derivative = integration_result.evaluation
 
-        beta_next = updated_beta if self.updateTerminalLevel else beta_cells.copy()
-        if not self.updateTerminalLevel:
-            beta_next[:, :-1] = updated_beta[:, :-1]
-        self.gainMedium.get("betaCells").value = np.clip(beta_next, 0.0, 1.0)
+        self.gainMedium.get("betaCells").value = np.clip(updated_beta, 0.0, 1.0)
         self._updateBetaVolumeFromCells()
 
         self._step += 1

--- a/tests/python/simulation/test_timeSteppedSimulation.py
+++ b/tests/python/simulation/test_timeSteppedSimulation.py
@@ -262,6 +262,7 @@ def testTimeSteppedSimulationAcceptsCustomPumpSolver(
     tau = 9.5e-4
     expected = tau * (0.25 / 1e-5) * (1.0 - np.exp(-1e-5 / tau))
     assert np.allclose(state.betaCells, expected)
+    assert np.allclose(state.betaCells[:, -1], expected)
 
 
 def testCustomPumpSolverCanReadAdditionalPumpProperties(


### PR DESCRIPTION
This PR fixes a bug, where the pumping routine did not update the last z-level of beta-cells during the pumping step. 
(This has already been present previously in the legacy script)