### PR TITLE
Use frozen-ASE RK4 in laserPumpCladding

### DIFF
--- a/docs/source/pythonAPI.rst
+++ b/docs/source/pythonAPI.rst
@@ -53,6 +53,7 @@ Simulation and time integration
    TimeIntegrationSolver
    ExplicitEuler
    ExponentialEuler
+   FrozenPhiAseRungeKutta4
    Heun
    ImplicitEuler
    Midpoint

--- a/docs/source/python_interface/simulation.rst
+++ b/docs/source/python_interface/simulation.rst
@@ -71,6 +71,8 @@ Each call to ``step()`` performs:
 4. During each derivative evaluation, ``Simulation`` updates ``betaVolume``,
    calls ``phiASE.run(...)`` when ASE is enabled, computes the pump rate through
    the configured pump solver, and combines pump, ASE, and fluorescence decay.
+   Higher-order solvers can therefore call the ASE backend more than once per
+   outer ``step()``.
 5. Clipping of updated beta values to ``[0, 1]``.
 6. Final ``betaVolume`` update from ``betaCells``.
 7. Latest-state update and ``onStep`` callbacks.
@@ -190,6 +192,11 @@ Time Integration
    step(rhs, betaCells, time, timeStep)
 
 Built-in solvers are documented in :doc:`utilities`.
+
+``FrozenPhiAseRungeKutta4`` is a special simulation-aware solver: it runs
+``phiASE`` once at the beginning of the outer step and keeps that ASE flux
+constant for all RK4 stages. Pump and local terms are still evaluated for each
+stage trial beta value.
 
 Beta Volume Mapping
 -------------------

--- a/docs/source/python_interface/utilities.rst
+++ b/docs/source/python_interface/utilities.rst
@@ -16,6 +16,7 @@ Import built-in solvers from ``HASEonGPU``:
        Heun,
        Midpoint,
        RungeKutta4,
+       FrozenPhiAseRungeKutta4,
        ImplicitEuler,
        ExponentialEuler,
    )
@@ -26,8 +27,14 @@ Available solvers:
 * ``Heun()``
 * ``Midpoint()``
 * ``RungeKutta4()``
+* ``FrozenPhiAseRungeKutta4()``
 * ``ImplicitEuler(iterations=8, tolerance=1e-10)``
 * ``ExponentialEuler()``
+
+``FrozenPhiAseRungeKutta4`` computes ``phiASE`` once per outer simulation step,
+then reuses that fixed ASE flux while RK4 re-evaluates the pump and local ASE
+coupling terms for each stage. Use it to reduce ASE backend cost when a
+stage-by-stage transport solve is not required.
 
 All solvers implement:
 

--- a/example/python_example/laserPumpCladding.py
+++ b/example/python_example/laserPumpCladding.py
@@ -27,13 +27,13 @@ from HASEonGPU import (  # noqa: E402
     calcGainFromState,
     Constants,
     CrossSectionData,
-    ExponentialEuler,
     GainMedium,
     MeshTopology,
     PhiASE,
     PumpProperties,
     Simulation,
     PumpRadiationProfile,
+    RungeKutta4,
     vtkWedge,
 )
 def printState(state):
@@ -65,19 +65,6 @@ def writeVtkFields(state, vtkOutputDir=scriptDir, claddingAbsorption=1.0, crossS
             "localGain": calcGainFromState(state, crossSections, nTot),
         },
     )
-
-
-def prePumpInitialState(simulation):
-    medium = simulation.gainMedium
-    beta_cells = np.asarray(medium.get("betaCells").value, dtype=np.float64).reshape(
-        medium.get("betaCells").expectedShape,
-        order="F",
-    )
-    dndt_pump = simulation._dndtPump(beta_cells)
-    tau = float(medium.get("crystalTFluo").value)
-    decay = np.exp(-simulation.timeStep / tau)
-    medium.get("betaCells").value = tau * dndt_pump * (1.0 - decay) + beta_cells * decay
-    simulation._updateBetaVolumeFromCells()
 
 
 def laserPumpCladdingMedium(numberOfLevels=10, thickness=None, cladAbsorption =5.5):
@@ -170,13 +157,12 @@ def runExample(
         gainMedium=medium,
         pump=pumpProperties,
         phiASE=phiAse,
-        timeIntegrationSolver=ExponentialEuler(),
+        timeIntegrationSolver=RungeKutta4(),
         timeStep=2e-5, #20 μs
         crossSections=spectralProperties,
         constants=Constants(c=3e8, h=6.626e-34), ## these constants match legacy skript values
         enableAse=enableAse,
     )
-    simulation.onInit(prePumpInitialState)
 
     simulation.onStep(printState)
     simulation.onStep(

--- a/example/python_example/laserPumpCladding.py
+++ b/example/python_example/laserPumpCladding.py
@@ -107,6 +107,7 @@ def runExample(
     pumpSteps=50,
     vtkOutputDir=scriptDir,
     enableAse=True,
+    prePump=True,
     **AseOverride,
 ):
     vtkOutputDir = Path(vtkOutputDir)
@@ -163,6 +164,7 @@ def runExample(
         crossSections=spectralProperties,
         constants=Constants(c=3e8, h=6.626e-34), ## these constants match legacy skript values
         enableAse=enableAse,
+        prePump=prePump,
     )
 
     simulation.onStep(printState)
@@ -195,6 +197,11 @@ def main(argv=None):
     parser.add_argument("--phi-ase-config", type=Path, default=defaultPhiAseConfigPath)
     parser.add_argument("--vtk-output-dir", type=Path, default=scriptDir)
     parser.add_argument("--disable-ase", action="store_true", help="Skip PhiASE backend runs and use zero ASE depletion")
+    parser.add_argument(
+        "--disable-pre-pump",
+        action="store_true",
+        help="Run ASE from the first simulation step instead of first seeding beta with pump only",
+    )
     args = parser.parse_args(argv)
 
     state = runExample(
@@ -204,6 +211,7 @@ def main(argv=None):
         pumpSteps=args.pumpSteps,
         vtkOutputDir=args.vtk_output_dir,
         enableAse=not args.disable_ase,
+        prePump=not args.disable_pre_pump,
     )
     print(f"phiAse shape: {state.phiAse.shape}")
     print(f"betaCells shape: {state.betaCells.shape}")

--- a/example/python_example/laserPumpCladding.py
+++ b/example/python_example/laserPumpCladding.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import numpy as np
 
+from pyInclude import FrozenPhiAseRungeKutta4
 
 scriptDir = Path(__file__).resolve().parent
 repoRoot = scriptDir.parents[1]
@@ -157,7 +158,7 @@ def runExample(
         gainMedium=medium,
         pump=pumpProperties,
         phiASE=phiAse,
-        timeIntegrationSolver=RungeKutta4(),
+        timeIntegrationSolver=FrozenPhiAseRungeKutta4(),
         timeStep=2e-5, #20 μs
         crossSections=spectralProperties,
         constants=Constants(c=3e8, h=6.626e-34), ## these constants match legacy skript values

--- a/pyInclude/__init__.py
+++ b/pyInclude/__init__.py
@@ -37,6 +37,7 @@ from .vtkWedge import vtkWedge
 from .timeIntegration import (
     ExplicitEuler,
     ExponentialEuler,
+    FrozenPhiAseRungeKutta4,
     Heun,
     ImplicitEuler,
     Midpoint,

--- a/pyInclude/simulation.py
+++ b/pyInclude/simulation.py
@@ -447,8 +447,10 @@ class Simulation:
     _pumpEnabled: bool = field(default=True, init=False, repr=False)
 
     def __post_init__(self):
-        if self.timeIntegrationSolver is None or not hasattr(self.timeIntegrationSolver, "step"):
-            raise ValueError("Simulation requires a timeIntegrationSolver with a step(rhs, betaCells, time, timeStep) method")
+        has_step = self.timeIntegrationSolver is not None and hasattr(self.timeIntegrationSolver, "step")
+        has_simulation_step = self.timeIntegrationSolver is not None and hasattr(self.timeIntegrationSolver, "stepSimulation")
+        if not has_step and not has_simulation_step:
+            raise ValueError("Simulation requires a timeIntegrationSolver with step(...) or stepSimulation(...)")
         if self.timeStep <= 0.0:
             raise ValueError("timeStep must be positive")
         if self.crossSections is None:
@@ -569,12 +571,20 @@ class Simulation:
             order="F",
         )
 
-        integration_result = self.timeIntegrationSolver.step(
-            self._timeDerivative,
-            beta_cells.copy(),
-            self._time,
-            self.timeStep,
-        )
+        if hasattr(self.timeIntegrationSolver, "stepSimulation"):
+            integration_result = self.timeIntegrationSolver.stepSimulation(
+                self,
+                beta_cells.copy(),
+                self._time,
+                self.timeStep,
+            )
+        else:
+            integration_result = self.timeIntegrationSolver.step(
+                self._timeDerivative,
+                beta_cells.copy(),
+                self._time,
+                self.timeStep,
+            )
         updated_beta = integration_result.betaCells
         derivative = integration_result.evaluation
 
@@ -672,17 +682,33 @@ class Simulation:
             self.gainMedium.get("betaCells").expectedShape,
             order="F",
         )
+        phi_ase, ase_result = self._runPhiAseForBeta(beta_cells)
+        return self._timeDerivativeWithFrozenPhiAse(beta_cells, time, phi_ase, ase_result)
+
+    def _runPhiAseForBeta(self, beta_cells):
+        beta_cells = np.asarray(beta_cells, dtype=np.float64).reshape(
+            self.gainMedium.get("betaCells").expectedShape,
+            order="F",
+        )
         self.gainMedium.get("betaCells").value = beta_cells
         self._updateBetaVolumeFromCells()
-        if self.enableAse:
-            self.phiASE.run(gainMedium=self.gainMedium, crossSections=self.crossSections)
-            ase_result = self.phiASE.getResults()
-            phi_ase = np.asarray(ase_result.phiAse, dtype=np.float64).reshape(beta_cells.shape, order="F")
-            dndt_ase = self._aseDerivative(phi_ase, betaCells=beta_cells)
-        else:
-            ase_result = None
-            phi_ase = np.zeros_like(beta_cells, dtype=np.float64)
-            dndt_ase = np.zeros_like(beta_cells, dtype=np.float64)
+        if not self.enableAse:
+            return np.zeros_like(beta_cells, dtype=np.float64), None
+
+        self.phiASE.run(gainMedium=self.gainMedium, crossSections=self.crossSections)
+        ase_result = self.phiASE.getResults()
+        phi_ase = np.asarray(ase_result.phiAse, dtype=np.float64).reshape(beta_cells.shape, order="F")
+        return phi_ase.copy(), ase_result
+
+    def _timeDerivativeWithFrozenPhiAse(self, beta_cells, time, phi_ase, ase_result):
+        beta_cells = np.asarray(beta_cells, dtype=np.float64).reshape(
+            self.gainMedium.get("betaCells").expectedShape,
+            order="F",
+        )
+        phi_ase = np.asarray(phi_ase, dtype=np.float64).reshape(beta_cells.shape, order="F")
+        self.gainMedium.get("betaCells").value = beta_cells
+        self._updateBetaVolumeFromCells()
+        dndt_ase = self._aseDerivative(phi_ase, betaCells=beta_cells) if self.enableAse else np.zeros_like(beta_cells)
         dndt_pump = self._dndtPump(beta_cells)
         tau = max(float(self.gainMedium.get("crystalTFluo").value), np.finfo(float).tiny)
         total_derivative = dndt_pump - dndt_ase - beta_cells / tau

--- a/pyInclude/simulation.py
+++ b/pyInclude/simulation.py
@@ -436,6 +436,8 @@ class Simulation:
     """Physical constants used by the pump integrator."""
     enableAse: bool = True
     """Whether each derivative evaluation runs ASE depletion through ``PhiASE``."""
+    prePump: bool = False
+    """When true, the first time step advances without ASE so pump can seed beta."""
 
     _time: float = field(default=0.0, init=False, repr=False)
     _step: int = field(default=0, init=False, repr=False)
@@ -685,6 +687,9 @@ class Simulation:
         phi_ase, ase_result = self._runPhiAseForBeta(beta_cells)
         return self._timeDerivativeWithFrozenPhiAse(beta_cells, time, phi_ase, ase_result)
 
+    def _aseEnabledForCurrentStep(self):
+        return self.enableAse and not (self.prePump and self._step == 0)
+
     def _runPhiAseForBeta(self, beta_cells):
         beta_cells = np.asarray(beta_cells, dtype=np.float64).reshape(
             self.gainMedium.get("betaCells").expectedShape,
@@ -692,7 +697,7 @@ class Simulation:
         )
         self.gainMedium.get("betaCells").value = beta_cells
         self._updateBetaVolumeFromCells()
-        if not self.enableAse:
+        if not self._aseEnabledForCurrentStep():
             return np.zeros_like(beta_cells, dtype=np.float64), None
 
         self.phiASE.run(gainMedium=self.gainMedium, crossSections=self.crossSections)
@@ -708,7 +713,11 @@ class Simulation:
         phi_ase = np.asarray(phi_ase, dtype=np.float64).reshape(beta_cells.shape, order="F")
         self.gainMedium.get("betaCells").value = beta_cells
         self._updateBetaVolumeFromCells()
-        dndt_ase = self._aseDerivative(phi_ase, betaCells=beta_cells) if self.enableAse else np.zeros_like(beta_cells)
+        dndt_ase = (
+            self._aseDerivative(phi_ase, betaCells=beta_cells)
+            if self._aseEnabledForCurrentStep()
+            else np.zeros_like(beta_cells)
+        )
         dndt_pump = self._dndtPump(beta_cells)
         tau = max(float(self.gainMedium.get("crystalTFluo").value), np.finfo(float).tiny)
         total_derivative = dndt_pump - dndt_ase - beta_cells / tau

--- a/pyInclude/timeIntegration.py
+++ b/pyInclude/timeIntegration.py
@@ -116,6 +116,46 @@ class RungeKutta4(TimeIntegrationSolver):
         return TimeIntegrationResult(updated, k4)
 
 
+class FrozenPhiAseRungeKutta4(TimeIntegrationSolver):
+    """Fourth-order beta update with one frozen ASE transport solve per step.
+
+    ``Simulation`` computes the ASE flux once from the step-start beta field
+    and reuses that fixed ``phiAse`` in all RK4 stages. Pump and local ASE
+    coupling terms are still re-evaluated for each trial beta value. This
+    reduces expensive ASE backend calls, but it is not identical to full RK4 of
+    the coupled beta/ASE-transport system.
+    """
+
+    name = "frozen-phi-ase-runge-kutta-4"
+
+    def stepSimulation(self, simulation, betaCells, time, timeStep):
+        """Advance one ``Simulation`` step while freezing the ASE flux."""
+        phi_ase, ase_result = simulation._runPhiAseForBeta(betaCells)
+        k1 = simulation._timeDerivativeWithFrozenPhiAse(betaCells, time, phi_ase, ase_result)
+        k2 = simulation._timeDerivativeWithFrozenPhiAse(
+            betaCells + 0.5 * timeStep * k1.derivative,
+            time + 0.5 * timeStep,
+            phi_ase,
+            ase_result,
+        )
+        k3 = simulation._timeDerivativeWithFrozenPhiAse(
+            betaCells + 0.5 * timeStep * k2.derivative,
+            time + 0.5 * timeStep,
+            phi_ase,
+            ase_result,
+        )
+        k4 = simulation._timeDerivativeWithFrozenPhiAse(
+            betaCells + timeStep * k3.derivative,
+            time + timeStep,
+            phi_ase,
+            ase_result,
+        )
+        updated = betaCells + (timeStep / 6.0) * (
+            k1.derivative + 2.0 * k2.derivative + 2.0 * k3.derivative + k4.derivative
+        )
+        return TimeIntegrationResult(updated, k4)
+
+
 class ImplicitEuler(TimeIntegrationSolver):
     """Fixed-point implicit Euler beta update for stiff beta dynamics."""
 

--- a/tests/python/simulation/test_laserPumpCladdingExample.py
+++ b/tests/python/simulation/test_laserPumpCladdingExample.py
@@ -38,9 +38,11 @@ class _FakePhiASE:
         self.laserProperties = None
         self.backend = overrides.get("backend", "FakeBackend")
         self._shape = None
+        self.runInputs = []
 
     def run(self, gainMedium=None, crossSections=None):
         self._shape = gainMedium.get("betaCells").expectedShape
+        self.runInputs.append(np.asarray(gainMedium.get("betaCells").value, dtype=np.float64).copy())
         return self
 
     def getResults(self):
@@ -70,6 +72,23 @@ def testLaserPumpCladdingExampleWritesVtkFromOnStep(monkeypatch, tmp_path, small
     assert state.step == 2
     scalars = _vtkScalarNames(second)
     assert {"betaCells", "phiASE", "dndtAse", "dndtPump", "cladAbs"}.issubset(scalars)
+
+
+def testLaserPumpCladdingExampleSkipsAseBackendForInitialStep(monkeypatch, tmp_path, smallGainMedium):
+    monkeypatch.setattr(laserPumpCladding, "OneDimensionalZTraversal", lambda: _ConstantPumpSolver())
+    monkeypatch.setattr(laserPumpCladding, "laserPumpCladdingMedium", lambda **kwargs: smallGainMedium)
+    phiAse = _FakePhiASE()
+    monkeypatch.setattr(
+        laserPumpCladding.PhiASE,
+        "fromYaml",
+        classmethod(lambda cls, filename, **overrides: phiAse),
+    )
+
+    state = laserPumpCladding.runExample(timeSlices=2, pumpSteps=1, vtkOutputDir=tmp_path)
+
+    assert state.step == 2
+    assert len(phiAse.runInputs) == 1
+    assert np.any(phiAse.runInputs[0] > 0.0)
 
 
 def testLaserPumpCladdingExamplePassesPumpStepsToSimulation(monkeypatch, tmp_path, smallGainMedium):

--- a/tests/python/simulation/test_timeSteppedSimulation.py
+++ b/tests/python/simulation/test_timeSteppedSimulation.py
@@ -605,6 +605,46 @@ def testFrozenPhiAseRungeKutta4RunsAseBackendOncePerStep(
     assert state.phiAse.shape == (smallTopology.numberOfPoints, smallTopology.levels)
 
 
+def testSimulationPrePumpSkipsAseBackendForInitialStepOnly(
+    smallTopology,
+    pumpProperties,
+    makeFakePhiAse,
+):
+    class ConstantPumpSolver:
+        def step(self, input, pump):
+            return np.asarray(input["betaCell"], dtype=np.float64) + 1.0e-6
+
+    pumpProperties.customProperties["solver"] = ConstantPumpSolver()
+    phiAse = makeFakePhiAse(smallTopology)
+    calls = []
+
+    def run(*args, **kwargs):
+        calls.append(np.asarray(kwargs["gainMedium"].get("betaCells").value).copy())
+        return phiAse
+
+    phiAse.run = run
+    simulation = Simulation(
+        gainMedium=_mediumLikeSmallTopology(smallTopology),
+        pump=pumpProperties,
+        phiASE=phiAse,
+        timeIntegrationSolver=FrozenPhiAseRungeKutta4(),
+        timeStep=1e-5,
+        enableAse=True,
+        prePump=True,
+    )
+
+    first = simulation.step()
+    second = simulation.step()
+
+    assert simulation.enableAse is True
+    assert first.aseResult is None
+    assert np.allclose(first.phiAse, 0.0)
+    assert np.allclose(first.dndtAse, 0.0)
+    assert second.aseResult is not None
+    assert len(calls) == 1
+    assert np.any(calls[0] > 0.0)
+
+
 def testFrozenPhiAseRungeKutta4SkipsAseBackendWhenDisabled(
     smallTopology,
     pumpProperties,

--- a/tests/python/simulation/test_timeSteppedSimulation.py
+++ b/tests/python/simulation/test_timeSteppedSimulation.py
@@ -13,6 +13,7 @@ from HASEonGPU import (
     CrossSectionData,
     ExponentialEuler,
     ExplicitEuler,
+    FrozenPhiAseRungeKutta4,
     GainMedium,
     Heun,
     ImplicitEuler,
@@ -563,13 +564,132 @@ def testTimeIntegrationSolverIsMandatory(
         raise AssertionError("Simulation accepted a missing timeIntegrationSolver")
 
 
+def _mediumLikeSmallTopology(smallTopology, betaCells=None):
+    if betaCells is None:
+        betaCells = np.zeros((smallTopology.numberOfPoints, smallTopology.levels))
+    return GainMedium(topology=smallTopology).withPhysicalProperties(
+        betaCells=betaCells,
+        claddingCellTypes=np.zeros(smallTopology.numberOfTriangles, dtype=np.uint32),
+        refractiveIndices=[1.8, 1.0, 1.8, 1.0],
+        reflectivities=np.zeros((2, smallTopology.numberOfTriangles)),
+        nTot=2.76e20,
+        crystalTFluo=9.5e-4,
+        claddingNumber=1,
+        claddingAbsorption=0.0,
+    )
+
+
+def testFrozenPhiAseRungeKutta4RunsAseBackendOncePerStep(
+    smallTopology,
+    pumpProperties,
+    makeFakePhiAse,
+):
+    phiAse = makeFakePhiAse(smallTopology)
+    calls = []
+
+    def run(*args, **kwargs):
+        calls.append(np.asarray(kwargs["gainMedium"].get("betaCells").value).copy())
+        return phiAse
+
+    phiAse.run = run
+    state = Simulation(
+        gainMedium=_mediumLikeSmallTopology(smallTopology),
+        pump=pumpProperties,
+        phiASE=phiAse,
+        timeIntegrationSolver=FrozenPhiAseRungeKutta4(),
+        timeStep=1e-5,
+    ).step()
+
+    assert len(calls) == 1
+    assert state.aseResult is not None
+    assert state.phiAse.shape == (smallTopology.numberOfPoints, smallTopology.levels)
+
+
+def testFrozenPhiAseRungeKutta4SkipsAseBackendWhenDisabled(
+    smallTopology,
+    pumpProperties,
+    makeFakePhiAse,
+):
+    class LinearPumpSolver:
+        def step(self, input, pump):
+            beta = np.asarray(input["betaCell"], dtype=np.float64)
+            return beta + input["_timeStep"] * (0.2 + 0.05 * beta)
+
+    pumpProperties.customProperties["solver"] = LinearPumpSolver()
+    initial = np.full((smallTopology.numberOfPoints, smallTopology.levels), 0.1)
+
+    frozenPhiAse = makeFakePhiAse(smallTopology)
+    frozenPhiAse.run = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("PhiASE.run should not be called when enableAse=False")
+    )
+    frozenState = Simulation(
+        gainMedium=_mediumLikeSmallTopology(smallTopology, betaCells=initial.copy()),
+        pump=pumpProperties,
+        phiASE=frozenPhiAse,
+        timeIntegrationSolver=FrozenPhiAseRungeKutta4(),
+        timeStep=1e-5,
+        enableAse=False,
+    ).step()
+
+    regularPhiAse = makeFakePhiAse(smallTopology)
+    regularPhiAse.run = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("PhiASE.run should not be called when enableAse=False")
+    )
+    regularState = Simulation(
+        gainMedium=_mediumLikeSmallTopology(smallTopology, betaCells=initial.copy()),
+        pump=pumpProperties,
+        phiASE=regularPhiAse,
+        timeIntegrationSolver=RungeKutta4(),
+        timeStep=1e-5,
+        enableAse=False,
+    ).step()
+
+    assert np.allclose(frozenState.betaCells, regularState.betaCells)
+    assert np.allclose(frozenState.phiAse, 0.0)
+    assert np.allclose(frozenState.dndtAse, 0.0)
+
+
+def testFrozenPhiAseDerivativeReusesPhiAseWhileAseCouplingFollowsBeta(
+    smallGainMedium,
+    smallTopology,
+    pumpProperties,
+    crossSections,
+    makeFakePhiAse,
+):
+    simulation = Simulation(
+        gainMedium=smallGainMedium,
+        pump=pumpProperties,
+        phiASE=makeFakePhiAse(smallTopology),
+        timeIntegrationSolver=FrozenPhiAseRungeKutta4(),
+        timeStep=1e-5,
+        crossSections=crossSections,
+    )
+    phiAse = np.full((smallTopology.numberOfPoints, smallTopology.levels), 2.0)
+    lowBeta = np.full_like(phiAse, 0.1)
+    highBeta = np.full_like(phiAse, 0.4)
+
+    low = simulation._timeDerivativeWithFrozenPhiAse(lowBeta, 0.0, phiAse, object())
+    high = simulation._timeDerivativeWithFrozenPhiAse(highBeta, 0.0, phiAse, object())
+
+    assert np.allclose(low.phiAse, phiAse)
+    assert np.allclose(high.phiAse, phiAse)
+    assert not np.array_equal(low.dndtAse, high.dndtAse)
+
+
 def testTimeIntegrationSolversCanStepSimulation(
     smallGainMedium,
     pumpProperties,
     makeFakePhiAse,
     smallTopology,
 ):
-    solvers = [ExplicitEuler(), Heun(), Midpoint(), RungeKutta4(), ImplicitEuler(iterations=2)]
+    solvers = [
+        ExplicitEuler(),
+        Heun(),
+        Midpoint(),
+        RungeKutta4(),
+        FrozenPhiAseRungeKutta4(),
+        ImplicitEuler(iterations=2),
+    ]
 
     for solver in solvers:
         medium = GainMedium(topology=smallTopology).withPhysicalProperties(


### PR DESCRIPTION
This PR updates `laserPumpCladding` to remove the separate `pre-pumping` step and run through the normal simulation time loop, a similiar mechanism is now integrated into the `Simulation` object by exposing a prePump parameter. If this is enabled ASE calculation is skipped for the t0 -> t1 Intervall, while only the pump routine is executed. 

  In addition adds `FrozenPhiAseRungeKutta4`, an RK4 variant that updates pump and local beta terms in all four RK stages, but computes phiASE only once per outer time step. This avoids four
  expensive backend ASE calls per step while preserving stage-wise local updates.