### PR TITLE
Keep time-step state resident between snapshots

### DIFF
--- a/docs/source/openpmdTransport.rst
+++ b/docs/source/openpmdTransport.rst
@@ -66,11 +66,20 @@ caller-managed simulation sessions are not supported.
 compiled ``calcPhiASE --cpp-control`` path. Python writes one initial input
 iteration with run-control attributes, then reads the snapshot series produced
 by the C++ time loop. For streaming backends, Python starts a dedicated
-snapshot receiver thread before sending the input iteration, so the C++ backend
-can drain its output stream and finish independently of slower Python
-``on_step`` callbacks such as VTK file writers. Caller-managed simulation
-openPMD sessions are not supported; the compiled run owns its transport
-lifetime.
+snapshot receiver thread before sending the input iteration. The autonomous
+backend owns stepping; Python only consumes the completed-step indices and
+fields selected by ``output_steps`` and ``output_fields`` in the initial
+iteration. A bounded handoff keeps memory use finite, so a slow callback can
+apply ordinary stream backpressure without turning Python into the step
+controller. Caller-managed simulation openPMD sessions are not supported; the
+compiled run owns its transport lifetime.
+
+With ``execution_mode="synchronized-debug"``, the input series remains open.
+After output step *N*, Python writes dynamic input iteration *N* and the backend
+waits for it before starting step *N+1*. Only records listed in
+``control_fields`` are written in these later iterations; currently that list
+may contain ``beta_volume``. Static topology, spectra, backend selection, and
+all other initialization records are transferred only in iteration zero.
 
 Provider Compatibility
 ----------------------
@@ -146,7 +155,7 @@ stores a VTK-compatible unstructured-cell layout in openPMD records:
 
 Main input field records are:
 
-* ``core_beta_volume`` for dynamic excited-state data
+* ``core_beta_volume`` for the authoritative dynamic time-integrator state
 * ``core_cladding_cell_type``, ``core_refractive_index``, and
   ``core_reflectivity`` for static material/surface data
 * ``core_lambda_absorption``, ``core_lambda_emission``,
@@ -179,12 +188,19 @@ metadata:
 * ``time_step`` and ``number_of_steps``
 * ``pump_steps``
 * ``enable_ase`` and ``pre_pump``
+* ``output_fields_string`` and ``control_fields_string`` as scalar JSON arrays
+  of field names; this scalar encoding is identical for ADIOS BP, ADIOS SST,
+  and HDF5
 * ``time_integrator`` (``explicit-euler``, ``heun``, ``midpoint``,
   ``runge-kutta-4``, ``frozen-phi-ase-runge-kutta-4``,
   ``implicit-euler``, or ``exponential-euler``)
 * ``implicit_iterations`` and ``implicit_tolerance`` for implicit Euler
 * ``pump_schema_version`` (currently ``1``), ``pump_ray_count``, and ``pump_rng_seed``
 * flattened source, spectrum, angular, profile, and planar-relay arrays
+
+Readers continue to accept the former ``output_fields`` and ``control_fields``
+string-vector attributes for existing series. New writers use only the scalar
+JSON attributes so that run control has one backend-independent wire format.
 
 The C++ backend writes one output iteration per completed step. Snapshot
 iterations contain the cell-centered ``core_beta_volume`` record plus ``core_result_phi_ase``,
@@ -200,9 +216,9 @@ Iteration Updates
 -----------------
 
 The first Python-written iteration contains the full static context: topology,
-material records, spectra, compute attributes, and the dynamic
-``core_beta_volume`` field. Later iterations normally contain only
-``core_beta_volume`` and reuse the cached static context from iteration 0.
+material records, spectra, compute attributes, and ``core_beta_volume``.
+Synchronized-debug control iterations contain only ``core_beta_volume`` and
+reuse the cached static context from iteration 0.
 
 Changing topology, spectra, material constants, or compute settings requires a
 new input series whose first iteration carries a complete static update.  This

--- a/docs/source/python_interface/simulation.rst
+++ b/docs/source/python_interface/simulation.rst
@@ -32,6 +32,78 @@ simulation does not retain the full history, so register ``on_step`` to store or
 write every snapshot.
 
 The full time loop, pump evaluation, ASE evaluation, derivative composition,
-time integration, and clipping run on cell-centered fields in C++/Alpaka. Python executes
-``on_init`` before launch and ``on_step`` callbacks as snapshots arrive.
-Per-step Python mutation is not supported inside a compiled run.
+time integration, and clipping run on cell-centered fields in C++/Alpaka.
+Backend selection, device-mesh creation, spectrum upload, forward-ASE queues,
+accumulators, reflection reservoirs, and integrator buffers happen once when a
+compiled run starts. The evolving ``beta_volume`` and derived ``phi_ase`` stay
+on the selected device between steps.
+
+Execution modes
+---------------
+
+``execution_mode="autonomous"`` is the normal and fastest contract. Python
+executes ``on_init`` once, writes one initialization iteration, and has no
+control contact with the C++ loop until it receives a requested snapshot. An
+openPMD streaming backend delivers snapshots while the run is active; a file
+backend returns them after the run. Snapshot consumers can create backpressure
+on a live stream, but they do not drive stepping.
+
+``execution_mode="synchronized-debug"`` is the explicit diagnostic contract.
+It requires a streaming backend, emits every completed step, and waits for a
+matching Python control iteration before continuing. Register ``beforeStep``
+callbacks to inspect the just-completed state and update fields named by
+``control_fields``. This mode intentionally synchronizes Python and the backend
+and should not be used for performance measurements.
+
+Snapshot schedule
+-----------------
+
+``output_steps`` is either omitted, meaning every completed step, or is a
+strictly increasing sequence of one-based completed-step indices. For example,
+one snapshot after pumping and one at the end can be selected by application
+code:
+
+.. code-block:: python
+
+   def pump_boundary_and_final(number_of_steps, pump_steps):
+       return tuple(sorted({min(number_of_steps, pump_steps), number_of_steps}))
+
+   simulation = Simulation(
+       # ... physical configuration ...
+       output_steps=pump_boundary_and_final(150, 40),
+   )
+
+Final-only output is only a schedule convenience, not a separate execution
+path:
+
+.. code-block:: python
+
+   from HASEonGPU import autonomous_final
+
+   simulation = Simulation(
+       # ...
+       output_steps=autonomous_final(150),
+   )
+
+The requested indices must not exceed the number of steps passed to ``step``.
+``synchronized-debug`` does not accept ``output_steps`` because every step is a
+synchronization boundary.
+
+Selectable fields
+-----------------
+
+``output_fields`` fixes the snapshot payload at initialization. Supported
+cell-centered fields are:
+
+* ``beta_volume``
+* ``phi_ase``
+* ``standard_error``
+* ``relative_standard_error``
+* ``total_rays``
+* ``dndt_ase``
+* ``dndt_pump``
+
+Unselected arrays are ``None`` in ``TimeStepState``. The synchronized-debug
+``control_fields`` list currently supports ``beta_volume``. Point-state names
+are deliberately unsupported: the current model and transport contract are
+cell/volume based throughout.

--- a/example/laserPumpCladding.py
+++ b/example/laserPumpCladding.py
@@ -185,6 +185,19 @@ CLADDING_SURFACE_ID = 3
 NUMBER_OF_Z_LAYERS = 10
 
 
+def laserPumpCladdingOutputSteps(timeSlices, pumpSteps):
+    """Observe the pump boundary, when reached, and the final time slice."""
+    finalStep = int(timeSlices)
+    if finalStep <= 0:
+        raise ValueError("timeSlices must be positive")
+    if pumpSteps is None:
+        return (finalStep,)
+    pumpBoundary = int(pumpSteps)
+    if pumpBoundary < 0:
+        raise ValueError("pumpSteps must be non-negative")
+    return tuple(sorted({step for step in (pumpBoundary, finalStep) if 0 < step <= finalStep}))
+
+
 def _assignLegacyTet4SurfaceDomains(topology):
     """Attach the legacy optical regions to its geometrically identical Tet4 mesh."""
     sample_points = np.asarray(topology.samplePoints, dtype=np.float64).copy()
@@ -276,6 +289,7 @@ def runExample(
     pumpRayCount=50000,
     pumpRngSeed=5489,
     reportTimings=False,
+    outputSteps=None,
     **AseOverride,
 ):
     vtkOutputDir = Path(vtkOutputDir)
@@ -342,6 +356,11 @@ def runExample(
         enable_ase=enableASE,
         pre_pump=prePump,
         report_timings=reportTimings,
+        output_steps=(
+            laserPumpCladdingOutputSteps(timeSlices, pumpSteps)
+            if outputSteps is None
+            else tuple(int(step) for step in outputSteps)
+        ),
     ).add_pump(
         pump,
         injection_method=SurfacePumpInjector(surface_domains="ase_bottom"),
@@ -366,6 +385,16 @@ def main(argv=None):
     parser.add_argument("--backend", type=str, default="UseConfig")
     parser.add_argument("--openpmd-backend", type=str, default="UseConfig")
     parser.add_argument("--timeSteps", type=int, default=150)
+    parser.add_argument(
+        "--output-steps",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Completed one-based step indices to emit. By default, emit only "
+            "the pump boundary and final step."
+        ),
+    )
     parser.add_argument(
         "--pumpSteps",
         type=int,
@@ -457,6 +486,7 @@ def main(argv=None):
         reportTimings=args.timings,
         pumpRayCount=args.pump_ray_count,
         pumpRngSeed=args.pump_rng_seed,
+        outputSteps=args.output_steps,
         **aseOverrides,
     )
     print(f"phiAse shape: {state.phi_ase.shape}")

--- a/include/core/calcForwardPhiAse.hpp
+++ b/include/core/calcForwardPhiAse.hpp
@@ -10,8 +10,10 @@
 #include <benchmark.hpp>
 #include <core/forwardSrm.hpp>
 #include <core/mesh.hpp>
+#include <kernels/forwardPhiAseMapping.hpp>
 #include <random/random.hpp>
 
+#include <chrono>
 #include <ctime>
 #include <stdexcept>
 #include <vector>
@@ -43,6 +45,319 @@ namespace hase::core
         double volumeSize);
 
     void finalizeForwardPhiAse(HostMesh const& hostMesh, ForwardPhiAseRawResult const& rawResult, Result& result);
+
+    void finalizeForwardPhiAse(
+        HostMesh const& hostMesh,
+        ForwardPhiAseRawResult const& rawResult,
+        double betaVolumeTotal,
+        Result& result);
+
+    template<alpaka::onHost::concepts::Device T_Device, typename T_Exec>
+    class ForwardPhiAseDeviceContext
+    {
+        using T_Queue = ALPAKA_TYPEOF(std::declval<T_Device>().makeQueue(alpaka::queueKind::nonBlocking));
+        using T_DoubleBuffer = ALPAKA_TYPEOF(alpaka::onHost::alloc<double>(std::declval<T_Device&>(), std::size_t{1}));
+        using T_FloatBuffer = ALPAKA_TYPEOF(alpaka::onHost::alloc<float>(std::declval<T_Device&>(), std::size_t{1}));
+        using T_UnsignedBuffer
+            = ALPAKA_TYPEOF(alpaka::onHost::alloc<unsigned>(std::declval<T_Device&>(), std::size_t{1}));
+
+    public:
+        ForwardPhiAseDeviceContext(
+            T_Device const& device,
+            T_Exec const& executor,
+            ExperimentParameters const& experiment,
+            unsigned volumeCount)
+            : m_devBundle(device, executor)
+            , m_queue(m_devBundle.device.makeQueue(alpaka::queueKind::nonBlocking))
+            , m_phi(alpaka::onHost::alloc<double>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_phiSquare(alpaka::onHost::alloc<double>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_volumeRayVisits(
+                  alpaka::onHost::alloc<unsigned>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_droppedRays(alpaka::onHost::alloc<unsigned>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_sigmaA(hase::alpakaUtils::toDevice(m_queue, experiment.sigmaA))
+            , m_sigmaE(hase::alpakaUtils::toDevice(m_queue, experiment.sigmaE))
+            , m_volumePhiAse(alpaka::onHost::alloc<float>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_standardError(alpaka::onHost::alloc<double>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_relativeStandardError(
+                  alpaka::onHost::alloc<double>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_volumeDndtAse(alpaka::onHost::alloc<double>(m_devBundle.device, static_cast<std::size_t>(volumeCount)))
+            , m_betaVolumeTotal(alpaka::onHost::alloc<double>(m_devBundle.device, std::size_t{1}))
+            , m_volumeCount(volumeCount)
+            , m_spectralCount(static_cast<unsigned>(experiment.sigmaA.size()))
+        {
+            if(experiment.useReflections)
+            {
+                m_srmWorkspace = std::make_unique<ForwardSrmWorkspace<T_Device>>(
+                    m_devBundle.device,
+                    volumeCount * tet4FaceCount,
+                    experiment.surfaceReservoirSize,
+                    std::max(experiment.maxRays, experiment.resolvedForwardRayCount()));
+            }
+        }
+
+        void begin(
+            DeviceMeshView const mesh,
+            unsigned rayCount,
+            unsigned rngSeed,
+            unsigned globalRayOffset,
+            unsigned globalRayCount,
+            double sourceStratificationOffset,
+            unsigned spectrumStratificationPhase,
+            double betaVolumeTotal,
+            ExperimentParameters const& experiment,
+            bool resetAccumulators = true)
+        {
+            m_started = std::chrono::steady_clock::now();
+            m_rayCount = rayCount;
+            if(resetAccumulators)
+                m_accumulatedRayCount = 0u;
+            m_accumulatedRayCount += rayCount;
+            if(rayCount == 0u)
+                return;
+
+            if(resetAccumulators)
+            {
+                alpaka::onHost::fill(m_queue, m_phi, 0.0, alpaka::Vec{static_cast<std::size_t>(m_volumeCount)});
+                alpaka::onHost::fill(m_queue, m_phiSquare, 0.0, alpaka::Vec{static_cast<std::size_t>(m_volumeCount)});
+                alpaka::onHost::fill(
+                    m_queue,
+                    m_volumeRayVisits,
+                    0u,
+                    alpaka::Vec{static_cast<std::size_t>(m_volumeCount)});
+                alpaka::onHost::fill(m_queue, m_droppedRays, 0u, alpaka::Vec{static_cast<std::size_t>(m_volumeCount)});
+            }
+
+            auto accumulation = hase::kernels::forward::ForwardAccumulationSpans{
+                m_phi,
+                m_phiSquare,
+                m_volumeRayVisits,
+                m_droppedRays};
+            auto spectrum = hase::kernels::forward::ForwardSpectrumSpans{m_sigmaA, m_sigmaE, m_spectralCount};
+            auto frameSpec = hase::alpakaUtils::getFrameSpec<uint32_t>(
+                m_devBundle.device,
+                m_devBundle.executor,
+                alpaka::Vec{rayCount});
+            m_srmResult = makeForwardRawResult(m_volumeCount);
+            m_srmResult.rayCount = rayCount;
+            if(experiment.useReflections)
+            {
+                if(!m_srmWorkspace)
+                    throw std::runtime_error("persistent forward SRM workspace was not initialized");
+                auto const controls = resolveSrmControls(experiment);
+                m_srmResult.srmMaxIterations = controls.maxIterations;
+                m_srmResult.srmDivergenceStreak = controls.divergenceStreak;
+                runForwardSrm(
+                    m_devBundle,
+                    m_queue,
+                    mesh,
+                    experiment,
+                    m_srmResult,
+                    rayCount,
+                    globalRayOffset,
+                    globalRayCount,
+                    sourceStratificationOffset,
+                    spectrumStratificationPhase,
+                    betaVolumeTotal,
+                    m_phi,
+                    m_phiSquare,
+                    m_volumeRayVisits,
+                    m_droppedRays,
+                    m_sigmaA,
+                    m_sigmaE,
+                    m_spectralCount,
+                    rngSeed,
+                    controls,
+                    *m_srmWorkspace);
+            }
+            else
+            {
+                BENCH_SYNC(m_queue, AccumulateForwardPhiAse);
+                m_queue.enqueue(
+                    frameSpec,
+                    alpaka::KernelBundle{
+                        hase::kernels::forward::AccumulateForwardPhiAse{},
+                        mesh,
+                        rayCount,
+                        globalRayOffset,
+                        globalRayCount,
+                        sourceStratificationOffset,
+                        spectrumStratificationPhase,
+                        betaVolumeTotal,
+                        accumulation,
+                        spectrum,
+                        rngSeed});
+            }
+        }
+
+        void finish(ForwardPhiAseRawResult& result, float& runtime, bool downloadAccumulators = true)
+        {
+            result = makeForwardRawResult(m_volumeCount);
+            result.rayCount = m_accumulatedRayCount;
+            result.srmStatus = m_srmResult.srmStatus;
+            result.srmPasses = m_srmResult.srmPasses;
+            result.srmRemainingFraction = m_srmResult.srmRemainingFraction;
+            result.srmMaxIterations = m_srmResult.srmMaxIterations;
+            result.srmDivergenceStreak = m_srmResult.srmDivergenceStreak;
+            if(m_rayCount == 0u)
+            {
+                runtime = 0.0f;
+                return;
+            }
+            if(downloadAccumulators)
+            {
+                alpaka::onHost::memcpy(m_queue, result.scoreSum, m_phi);
+                alpaka::onHost::memcpy(m_queue, result.scoreSquareSum, m_phiSquare);
+                alpaka::onHost::memcpy(m_queue, result.totalRays, m_volumeRayVisits);
+                alpaka::onHost::memcpy(m_queue, result.droppedRays, m_droppedRays);
+            }
+            alpaka::onHost::wait(m_queue);
+            runtime = static_cast<float>(
+                std::chrono::duration<double>(std::chrono::steady_clock::now() - m_started).count());
+        }
+
+        void evaluate(
+            DeviceMeshView const mesh,
+            ForwardPhiAseRawResult& result,
+            float& runtime,
+            unsigned rayCount,
+            unsigned rngSeed,
+            unsigned globalRayOffset,
+            unsigned globalRayCount,
+            double sourceStratificationOffset,
+            unsigned spectrumStratificationPhase,
+            double betaVolumeTotal,
+            ExperimentParameters const& experiment)
+        {
+            begin(
+                mesh,
+                rayCount,
+                rngSeed,
+                globalRayOffset,
+                globalRayCount,
+                sourceStratificationOffset,
+                spectrumStratificationPhase,
+                betaVolumeTotal,
+                experiment);
+            finish(result, runtime);
+        }
+
+        void finalizeCellPhiAse(
+            DeviceMeshView const mesh,
+            unsigned rayCount,
+            double betaVolumeTotal,
+            double fluorescenceRate,
+            double sigmaA,
+            double sigmaE)
+        {
+            hase::kernels::enqueueFinalizeForwardCellPhiAse(
+                m_devBundle,
+                m_queue,
+                mesh,
+                m_phi,
+                m_phiSquare,
+                m_droppedRays,
+                m_volumePhiAse,
+                m_standardError,
+                m_relativeStandardError,
+                m_volumeDndtAse,
+                rayCount,
+                betaVolumeTotal,
+                fluorescenceRate,
+                sigmaA,
+                sigmaE);
+            alpaka::onHost::wait(m_queue);
+        }
+
+        double rebuildBetaVolumePrefix(DeviceMeshContainer<T_Device>& meshContainer, auto const& betaVolume)
+        {
+            auto mesh = meshContainer.toView();
+            mesh.betaVolume = std::span<double const>(betaVolume.data(), betaVolume.getMdSpan().getExtents().x());
+            hase::kernels::enqueueBuildBetaVolumePrefix(
+                m_devBundle,
+                m_queue,
+                mesh,
+                betaVolume,
+                meshContainer.betaVolumePrefix,
+                m_betaVolumeTotal);
+            std::vector<double> hostTotal(1u, 0.0);
+            alpaka::onHost::memcpy(m_queue, hostTotal, m_betaVolumeTotal);
+            alpaka::onHost::wait(m_queue);
+            return hostTotal.front();
+        }
+
+        std::vector<double> downloadVolumeDndtAse()
+        {
+            std::vector<double> result(m_volumeCount, 0.0);
+            alpaka::onHost::memcpy(m_queue, result, m_volumeDndtAse);
+            alpaka::onHost::wait(m_queue);
+            return result;
+        }
+
+        Result downloadFinalizedResult(
+            bool includePhiAse,
+            bool includeStandardError,
+            bool includeRelativeStandardError,
+            bool includeTotalRays)
+        {
+            Result result;
+            if(includePhiAse)
+            {
+                result.phiAse.resize(m_volumeCount);
+                alpaka::onHost::memcpy(m_queue, result.phiAse, m_volumePhiAse);
+            }
+            if(includeStandardError)
+            {
+                result.standardError.resize(m_volumeCount);
+                alpaka::onHost::memcpy(m_queue, result.standardError, m_standardError);
+            }
+            if(includeRelativeStandardError)
+            {
+                result.relativeStandardError.resize(m_volumeCount);
+                alpaka::onHost::memcpy(m_queue, result.relativeStandardError, m_relativeStandardError);
+            }
+            if(includeTotalRays)
+            {
+                result.totalRays.resize(m_volumeCount);
+                result.droppedRays.resize(m_volumeCount);
+                alpaka::onHost::memcpy(m_queue, result.totalRays, m_volumeRayVisits);
+                alpaka::onHost::memcpy(m_queue, result.droppedRays, m_droppedRays);
+            }
+            alpaka::onHost::wait(m_queue);
+            return result;
+        }
+
+        [[nodiscard]] auto& volumePhiAse()
+        {
+            return m_volumePhiAse;
+        }
+
+        [[nodiscard]] auto& volumeDndtAse()
+        {
+            return m_volumeDndtAse;
+        }
+
+    private:
+        hase::alpakaUtils::DevBundle<T_Device, T_Exec> m_devBundle;
+        T_Queue m_queue;
+        T_DoubleBuffer m_phi;
+        T_DoubleBuffer m_phiSquare;
+        T_UnsignedBuffer m_volumeRayVisits;
+        T_UnsignedBuffer m_droppedRays;
+        T_DoubleBuffer m_sigmaA;
+        T_DoubleBuffer m_sigmaE;
+        T_FloatBuffer m_volumePhiAse;
+        T_DoubleBuffer m_standardError;
+        T_DoubleBuffer m_relativeStandardError;
+        T_DoubleBuffer m_volumeDndtAse;
+        T_DoubleBuffer m_betaVolumeTotal;
+        std::unique_ptr<ForwardSrmWorkspace<T_Device>> m_srmWorkspace;
+        ForwardPhiAseRawResult m_srmResult;
+        unsigned m_volumeCount;
+        unsigned m_spectralCount;
+        unsigned m_rayCount = 0u;
+        unsigned m_accumulatedRayCount = 0u;
+        std::chrono::steady_clock::time_point m_started;
+    };
 
     template<alpaka::onHost::concepts::Device T_Device, typename T_Exec>
     float calcForwardPhiAseRaw(
@@ -139,6 +454,11 @@ namespace hase::core
         }
         else
         {
+            ForwardSrmWorkspace<T_Device> workspace{
+                devBundle.device,
+                volumeCount * tet4FaceCount,
+                experiment.surfaceReservoirSize,
+                rayCount};
             runForwardSrm(
                 devBundle,
                 queue,
@@ -159,7 +479,8 @@ namespace hase::core
                 dSigmaE,
                 static_cast<unsigned>(experiment.sigmaA.size()),
                 threadLocalStridingRNG,
-                srmControls);
+                srmControls,
+                workspace);
         }
 
         alpaka::onHost::memcpy(queue, result.scoreSum, dPhiAccumulator);

--- a/include/core/calcPhiAseMpi.hpp
+++ b/include/core/calcPhiAseMpi.hpp
@@ -43,6 +43,7 @@
 #    include <iostream>
 #    include <limits>
 #    include <ranges>
+#    include <stdexcept>
 #    include <vector>
 
 // Nodes
@@ -114,10 +115,28 @@ namespace hase::core
         }
 
         int const localDeviceCount = static_cast<int>(meshes.size());
-        int const devicesPerRank = localDeviceCount / localSize;
-        int const deviceRemainder = localDeviceCount % localSize;
-        int const firstDevice = localRank * devicesPerRank + std::min(localRank, deviceRemainder);
-        int const assignedDeviceCount = devicesPerRank + (localRank < deviceRemainder ? 1 : 0);
+        if(localDeviceCount == 0)
+            throw std::runtime_error("MPI forward ASE requires at least one local device on every rank");
+
+        // Prefer disjoint device subsets when the node has at least as many
+        // devices as ranks.  Otherwise every rank still participates by using
+        // its own process-local queue/context on a round-robin shared device.
+        // In particular, CPU backends commonly expose one logical device even
+        // though multiple MPI ranks can execute against it independently.
+        int firstDevice = 0;
+        int assignedDeviceCount = 0;
+        if(localSize <= localDeviceCount)
+        {
+            int const devicesPerRank = localDeviceCount / localSize;
+            int const deviceRemainder = localDeviceCount % localSize;
+            firstDevice = localRank * devicesPerRank + std::min(localRank, deviceRemainder);
+            assignedDeviceCount = devicesPerRank + (localRank < deviceRemainder ? 1 : 0);
+        }
+        else
+        {
+            firstDevice = localRank % localDeviceCount;
+            assignedDeviceCount = 1;
+        }
 
         MPI_Comm activeComm = MPI_COMM_NULL;
         int const activeColor = assignedDeviceCount > 0 ? 0 : MPI_UNDEFINED;
@@ -171,28 +190,25 @@ namespace hase::core
         MPI_Allreduce(&gpuNodeMinContribution, &minGpusPerNode, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
         MPI_Allreduce(&gpuNodeMaxContribution, &maxGpusPerNode, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
 
-        if(rank == HEAD_NODE)
-        {
-            topology.activeNodes = static_cast<unsigned>(activeNodesTotal);
-            topology.activeRanks = static_cast<unsigned>(activeRanksTotal);
-            topology.activeGpus = static_cast<unsigned>(activeDevicesTotal);
-            topology.avgActiveRanksPerNode
-                = activeNodesTotal > 0 ? static_cast<double>(activeRanksTotal) / static_cast<double>(activeNodesTotal)
-                                       : 0.0;
-            topology.minActiveRanksPerNode = minActiveRanksPerNode == std::numeric_limits<int>::max()
-                                                 ? 0u
-                                                 : static_cast<unsigned>(minActiveRanksPerNode);
-            topology.maxActiveRanksPerNode = static_cast<unsigned>(maxActiveRanksPerNode);
-            topology.avgGpusPerRank = activeRanksTotal > 0 ? static_cast<double>(activeDevicesTotal)
-                                                                 / static_cast<double>(activeRanksTotal)
-                                                           : 0.0;
-            topology.avgGpusPerNode = activeNodesTotal > 0 ? static_cast<double>(activeDevicesTotal)
-                                                                 / static_cast<double>(activeNodesTotal)
-                                                           : 0.0;
-            topology.minGpusPerNode
-                = minGpusPerNode == std::numeric_limits<int>::max() ? 0u : static_cast<unsigned>(minGpusPerNode);
-            topology.maxGpusPerNode = static_cast<unsigned>(maxGpusPerNode);
-        }
+        topology.activeNodes = static_cast<unsigned>(activeNodesTotal);
+        topology.activeRanks = static_cast<unsigned>(activeRanksTotal);
+        topology.activeGpus = static_cast<unsigned>(activeDevicesTotal);
+        topology.avgActiveRanksPerNode
+            = activeNodesTotal > 0 ? static_cast<double>(activeRanksTotal) / static_cast<double>(activeNodesTotal)
+                                   : 0.0;
+        topology.minActiveRanksPerNode = minActiveRanksPerNode == std::numeric_limits<int>::max()
+                                             ? 0u
+                                             : static_cast<unsigned>(minActiveRanksPerNode);
+        topology.maxActiveRanksPerNode = static_cast<unsigned>(maxActiveRanksPerNode);
+        topology.avgGpusPerRank = activeRanksTotal > 0
+                                      ? static_cast<double>(activeDevicesTotal) / static_cast<double>(activeRanksTotal)
+                                      : 0.0;
+        topology.avgGpusPerNode = activeNodesTotal > 0
+                                      ? static_cast<double>(activeDevicesTotal) / static_cast<double>(activeNodesTotal)
+                                      : 0.0;
+        topology.minGpusPerNode
+            = minGpusPerNode == std::numeric_limits<int>::max() ? 0u : static_cast<unsigned>(minGpusPerNode);
+        topology.maxGpusPerNode = static_cast<unsigned>(maxGpusPerNode);
 
         std::array<int, 8> const rankWorkInfo{
             rank,
@@ -290,11 +306,8 @@ namespace hase::core
         int const volumeCount = static_cast<int>(mesh.numberOfCells);
         int totalUsedDevices = 0;
         adaptiveLaunches = 0u;
-        if(activeRank == HEAD_NODE)
-        {
-            result = makeForwardRawResult(mesh.numberOfCells);
-            convergenceRayCounts.assign(mesh.numberOfCells, 0u);
-        }
+        result = makeForwardRawResult(mesh.numberOfCells);
+        convergenceRayCounts.assign(mesh.numberOfCells, 0u);
         unsigned accumulatedRayCount = 0u;
 
         for(unsigned completedIncreases = 0u;; ++completedIncreases)
@@ -331,72 +344,55 @@ namespace hase::core
             }
 
             ForwardPhiAseRawResult batchResult = makeForwardRawResult(mesh.numberOfCells);
-            MPI_Reduce(
+            MPI_Allreduce(
                 localResult.scoreSum.data(),
-                activeRank == HEAD_NODE ? batchResult.scoreSum.data() : nullptr,
+                batchResult.scoreSum.data(),
                 volumeCount,
                 MPI_DOUBLE,
                 MPI_SUM,
-                HEAD_NODE,
                 activeComm);
-            MPI_Reduce(
+            MPI_Allreduce(
                 localResult.scoreSquareSum.data(),
-                activeRank == HEAD_NODE ? batchResult.scoreSquareSum.data() : nullptr,
+                batchResult.scoreSquareSum.data(),
                 volumeCount,
                 MPI_DOUBLE,
                 MPI_SUM,
-                HEAD_NODE,
                 activeComm);
-            MPI_Reduce(
+            MPI_Allreduce(
                 localResult.totalRays.data(),
-                activeRank == HEAD_NODE ? batchResult.totalRays.data() : nullptr,
+                batchResult.totalRays.data(),
                 volumeCount,
                 MPI_UNSIGNED,
                 MPI_SUM,
-                HEAD_NODE,
                 activeComm);
-            MPI_Reduce(
+            MPI_Allreduce(
                 localResult.droppedRays.data(),
-                activeRank == HEAD_NODE ? batchResult.droppedRays.data() : nullptr,
+                batchResult.droppedRays.data(),
                 volumeCount,
                 MPI_UNSIGNED,
                 MPI_SUM,
-                HEAD_NODE,
                 activeComm);
-            MPI_Reduce(
-                &localResult.rayCount,
-                activeRank == HEAD_NODE ? &batchResult.rayCount : nullptr,
-                1,
-                MPI_UNSIGNED,
-                MPI_SUM,
-                HEAD_NODE,
-                activeComm);
+            MPI_Allreduce(&localResult.rayCount, &batchResult.rayCount, 1, MPI_UNSIGNED, MPI_SUM, activeComm);
 
             float maxBatchRuntime = 0.0f;
-            MPI_Reduce(&batchRuntime, &maxBatchRuntime, 1, MPI_FLOAT, MPI_MAX, HEAD_NODE, activeComm);
+            MPI_Allreduce(&batchRuntime, &maxBatchRuntime, 1, MPI_FLOAT, MPI_MAX, activeComm);
             int batchTotalUsedDevices = 0;
-            MPI_Reduce(&batchUsedDevices, &batchTotalUsedDevices, 1, MPI_INT, MPI_SUM, HEAD_NODE, activeComm);
+            MPI_Allreduce(&batchUsedDevices, &batchTotalUsedDevices, 1, MPI_INT, MPI_SUM, activeComm);
 
-            int stop = 0;
-            if(activeRank == HEAD_NODE)
-            {
-                mergeForwardRawResult(result, batchResult);
-                maxRankRuntime += maxBatchRuntime;
-                totalUsedDevices = std::max(totalUsedDevices, batchTotalUsedDevices);
-                ++adaptiveLaunches;
-                Result provisional;
-                finalizeForwardPhiAse(hostMesh, result, provisional);
-                recordAdaptiveRayConvergence(
-                    provisional,
-                    targetRayCount,
-                    experiment.relativeStandardErrorThreshold,
-                    convergenceRayCounts);
-                stop = experiment.forwardRayCount != 0u || targetRayCount == experiment.maxRays
-                       || forwardResultMeetsRelativeStandardError(
-                           provisional,
-                           experiment.relativeStandardErrorThreshold);
-            }
-            MPI_Bcast(&stop, 1, MPI_INT, HEAD_NODE, activeComm);
+            mergeForwardRawResult(result, batchResult);
+            maxRankRuntime += maxBatchRuntime;
+            totalUsedDevices = std::max(totalUsedDevices, batchTotalUsedDevices);
+            ++adaptiveLaunches;
+            Result provisional;
+            finalizeForwardPhiAse(hostMesh, result, provisional);
+            recordAdaptiveRayConvergence(
+                provisional,
+                targetRayCount,
+                experiment.relativeStandardErrorThreshold,
+                convergenceRayCounts);
+            int const stop
+                = experiment.forwardRayCount != 0u || targetRayCount == experiment.maxRays
+                  || forwardResultMeetsRelativeStandardError(provisional, experiment.relativeStandardErrorThreshold);
             accumulatedRayCount = targetRayCount;
             if(stop != 0)
             {
@@ -420,7 +416,7 @@ namespace hase::core
         }
 
 
-        return activeRank == HEAD_NODE ? static_cast<float>(totalUsedDevices) : 0.0f;
+        return static_cast<float>(totalUsedDevices);
     }
 #endif
 

--- a/include/core/forwardPhiAseEvaluator.hpp
+++ b/include/core/forwardPhiAseEvaluator.hpp
@@ -1,0 +1,396 @@
+/**
+ * Copyright 2026 Tim Hanel
+ *
+ * This file is part of HASEonGPU
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+
+#include <alpakaUtils/memory.hpp>
+#include <core/calcForwardPhiAse.hpp>
+#include <core/calcPhiAseThreaded.hpp>
+#include <core/forwardPhiAseUtilities.hpp>
+#include <core/mesh.hpp>
+#include <core/types.hpp>
+#include <random/random.hpp>
+
+#if !defined(DISABLE_MPI) && defined(MPI_FOUND)
+#    include <core/calcPhiAseMpi.hpp>
+#endif
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace hase::core
+{
+    namespace detail
+    {
+        template<typename T_Buffer>
+        std::vector<typename T_Buffer::value_type> copyToVector(auto const& queue, T_Buffer const& buffer)
+        {
+            auto hostBuffer = alpaka::onHost::allocHostLike(buffer);
+            alpaka::onHost::memcpy(queue, hostBuffer, buffer);
+            alpaka::onHost::wait(queue);
+            auto const* data = alpaka::onHost::data(hostBuffer);
+            return {data, data + buffer.getExtents().product()};
+        }
+
+        template<typename T_Buffer, typename T>
+        void copyVectorToBuffer(auto const& queue, std::vector<T> const& values, T_Buffer& buffer)
+        {
+            auto hostView = alpaka::makeView(alpaka::api::host, values.data(), alpaka::Vec{values.size()});
+            alpaka::onHost::memcpy(queue, buffer, hostView);
+        }
+    } // namespace detail
+
+    struct ForwardPhiAseEvaluation
+    {
+        bool deviceResidentPhi = false;
+        float runtime = 0.0f;
+        unsigned usedDevices = 0u;
+        unsigned rayCount = 0u;
+        unsigned adaptiveLaunches = 0u;
+        RuntimeTopology topology;
+        std::vector<unsigned> convergenceRayCounts;
+    };
+
+    template<typename T_Device, typename T_Executor>
+    class ForwardPhiAseContext
+    {
+    public:
+        ForwardPhiAseContext(
+            std::vector<T_Device> devices,
+            T_Executor executor,
+            ExperimentParameters const& experiment,
+            HostMesh& hostMesh)
+            : m_executor(std::move(executor))
+        {
+            if(devices.empty())
+                throw std::runtime_error("forward ASE context requires at least one device");
+            m_meshes.reserve(devices.size());
+            for(auto& device : devices)
+                m_meshes.emplace_back(hostMesh.toDevice(device));
+            m_deviceContexts.reserve(m_meshes.size());
+            for(auto const& mesh : m_meshes)
+            {
+                m_deviceContexts.emplace_back(
+                    std::make_unique<ForwardPhiAseDeviceContext<T_Device, T_Executor>>(
+                        mesh.m_device,
+                        m_executor,
+                        experiment,
+                        hostMesh.numberOfCells));
+            }
+        }
+
+        [[nodiscard]] T_Device& primaryDevice()
+        {
+            return m_meshes.front().m_device;
+        }
+
+        [[nodiscard]] DeviceMeshContainer<T_Device>& primaryMesh()
+        {
+            return m_meshes.front();
+        }
+
+        [[nodiscard]] auto& primaryBetaVolume()
+        {
+            return m_meshes.front().betaVolume;
+        }
+
+        [[nodiscard]] bool requiresHostBetaVolume() const
+        {
+            return m_meshes.size() > 1u;
+        }
+
+        std::vector<double> downloadPrimaryVolumeDndtAse()
+        {
+            return m_deviceContexts.front()->downloadVolumeDndtAse();
+        }
+
+        Result downloadPrimaryResult(
+            bool includePhiAse,
+            bool includeStandardError,
+            bool includeRelativeStandardError,
+            bool includeTotalRays)
+        {
+            return m_deviceContexts.front()->downloadFinalizedResult(
+                includePhiAse,
+                includeStandardError,
+                includeRelativeStandardError,
+                includeTotalRays);
+        }
+
+        [[nodiscard]] auto& primaryVolumeDndtAse()
+        {
+            return m_deviceContexts.front()->volumeDndtAse();
+        }
+
+        [[nodiscard]] auto& primaryVolumePhiAse()
+        {
+            return m_deviceContexts.front()->volumePhiAse();
+        }
+
+        ForwardPhiAseEvaluation evaluate(
+            ExperimentParameters& experiment,
+            ComputeParameters& compute,
+            HostMesh& hostMesh,
+            auto const& betaVolume,
+            Result& result,
+            bool allowDeviceResident = true)
+        {
+            bool const mpiHostCombined = compute.parallelMode == ParallelMode::MPI;
+            refreshDynamicMeshes(betaVolume, hostMesh, requiresHostBetaVolume() || mpiHostCombined, mpiHostCombined);
+            if(!experiment.isForwardPropagation())
+                throw std::runtime_error("Only forward volume propagation is supported by the openPMD backend.");
+
+            float runtime = 0.0f;
+            unsigned const maxDevices = static_cast<unsigned>(m_meshes.size());
+            std::vector<float> runtimes(maxDevices, 0.0f);
+            unsigned usedDevices = 0u;
+            RuntimeTopology topology;
+            ForwardPhiAseRawResult rawResult;
+            unsigned adaptiveLaunches = 0u;
+            std::vector<unsigned> convergenceRayCounts;
+            bool hostResultAvailable = false;
+
+            if(compute.parallelMode == ParallelMode::SINGLE)
+            {
+                unsigned const rngSeed = baseRngSeed(compute);
+                for(unsigned completedIncreases = 0u;; ++completedIncreases)
+                {
+                    unsigned const targetRayCount = adaptiveRayTarget(experiment, compute, completedIncreases);
+                    unsigned const batchRayCount = targetRayCount - rawResult.rayCount;
+                    unsigned const activeDevices = std::min(maxDevices, batchRayCount);
+                    if(batchRayCount == 0u)
+                    {
+                        if(targetRayCount == experiment.maxRays || experiment.forwardRayCount != 0u)
+                            break;
+                        continue;
+                    }
+                    if(activeDevices == 0u)
+                        break;
+
+                    std::fill(runtimes.begin(), runtimes.end(), 0.0f);
+                    unsigned const launchSeed = random::seedForAdaptiveLaunch(rngSeed, adaptiveLaunches);
+                    bool const terminalLaunch
+                        = experiment.forwardRayCount != 0u || targetRayCount == experiment.maxRays;
+                    bool const downloadAccumulators = !allowDeviceResident || activeDevices > 1u || !terminalLaunch;
+                    auto const batchResult = evaluatePersistentBatch(
+                        experiment,
+                        hostMesh,
+                        betaVolume,
+                        activeDevices,
+                        batchRayCount,
+                        targetRayCount,
+                        launchSeed,
+                        runtimes,
+                        adaptiveLaunches == 0u,
+                        downloadAccumulators);
+                    rawResult = batchResult;
+                    runtime += *std::ranges::max_element(runtimes);
+                    usedDevices = std::max(usedDevices, activeDevices);
+                    ++adaptiveLaunches;
+                    if(downloadAccumulators)
+                    {
+                        finalizeForwardPhiAse(hostMesh, rawResult, m_betaVolumeTotal, result);
+                        hostResultAvailable = true;
+                        recordAdaptiveRayConvergence(
+                            result,
+                            targetRayCount,
+                            experiment.relativeStandardErrorThreshold,
+                            convergenceRayCounts);
+                    }
+                    if(terminalLaunch
+                       || forwardResultMeetsRelativeStandardError(result, experiment.relativeStandardErrorThreshold))
+                        break;
+                }
+                topology.activeNodes = 1u;
+                topology.activeRanks = 1u;
+                topology.avgActiveRanksPerNode = 1.0;
+                topology.minActiveRanksPerNode = 1u;
+                topology.maxActiveRanksPerNode = 1u;
+                topology.activeGpus = usedDevices;
+                topology.avgGpusPerRank = static_cast<double>(usedDevices);
+                topology.avgGpusPerNode = static_cast<double>(usedDevices);
+                topology.minGpusPerNode = usedDevices;
+                topology.maxGpusPerNode = usedDevices;
+            }
+            else if(compute.parallelMode == ParallelMode::MPI)
+            {
+#if defined(MPI_FOUND) && !defined(DISABLE_MPI)
+                usedDevices = hase::core::calcForwardPhiAseMPI(
+                    m_executor,
+                    experiment,
+                    compute,
+                    hostMesh,
+                    m_meshes,
+                    rawResult,
+                    topology,
+                    runtime,
+                    adaptiveLaunches,
+                    convergenceRayCounts);
+                hostResultAvailable = true;
+#else
+                throw std::runtime_error("MPI parallel mode is unavailable in this build");
+#endif
+            }
+            else
+                throw std::runtime_error("unsupported forward ASE parallel mode '" + compute.parallelMode + "'");
+
+            if(usedDevices == 0u)
+            {
+                result = Result{};
+                return ForwardPhiAseEvaluation{};
+            }
+            if(hostResultAvailable)
+                finalizeForwardPhiAse(hostMesh, rawResult, m_betaVolumeTotal, result);
+            else
+            {
+                result = Result{};
+                result.srmStatus = rawResult.srmStatus;
+                result.srmPasses = rawResult.srmPasses;
+                result.srmRemainingFraction = rawResult.srmRemainingFraction;
+                result.srmMaxIterations = rawResult.srmMaxIterations;
+                result.srmDivergenceStreak = rawResult.srmDivergenceStreak;
+            }
+            // The persistent single-device path finalizes directly in
+            // m_deviceContexts.  MPI currently combines host accumulators, so
+            // its result must be copied back even when only one device exists.
+            bool const deviceResidentPhi
+                = allowDeviceResident && compute.parallelMode == ParallelMode::SINGLE && usedDevices == 1u;
+            double const fluorescenceRate = hostMesh.nTot / hostMesh.crystalTFluo;
+            for(unsigned volume = 0u;
+                hostResultAvailable && volume < result.phiAse.size() && volume < hostMesh.betaVolume.size();
+                ++volume)
+            {
+                result.phiAse[volume] *= fluorescenceRate;
+                result.standardError[volume] *= fluorescenceRate;
+                if(!deviceResidentPhi)
+                {
+                    result.dndtAse[volume] = calcVolumeDndtAse(
+                        hostMesh,
+                        experiment.maxSigmaA,
+                        experiment.maxSigmaE,
+                        result.phiAse[volume],
+                        volume);
+                }
+            }
+            if(deviceResidentPhi)
+            {
+                m_deviceContexts.front()->finalizeCellPhiAse(
+                    primaryMeshView(betaVolume),
+                    rawResult.rayCount,
+                    m_betaVolumeTotal,
+                    fluorescenceRate,
+                    experiment.maxSigmaA,
+                    experiment.maxSigmaE);
+            }
+            return ForwardPhiAseEvaluation{
+                deviceResidentPhi,
+                runtime,
+                usedDevices,
+                rawResult.rayCount,
+                adaptiveLaunches,
+                topology,
+                std::move(convergenceRayCounts)};
+        }
+
+    private:
+        ForwardPhiAseRawResult evaluatePersistentBatch(
+            ExperimentParameters const& experiment,
+            HostMesh const& hostMesh,
+            auto const& betaVolume,
+            unsigned activeDevices,
+            unsigned rayCount,
+            unsigned accumulatedRayCount,
+            unsigned baseSeed,
+            std::vector<float>& runtimes,
+            bool resetAccumulators,
+            bool downloadAccumulators)
+        {
+            ForwardPhiAseRawResult combined = makeForwardRawResult(hostMesh.numberOfCells);
+            if(rayCount == 0u || activeDevices == 0u)
+                return combined;
+
+            unsigned const raysPerDevice = rayCount / activeDevices;
+            unsigned const remainder = rayCount % activeDevices;
+            double const betaVolumeTotal = m_betaVolumeTotal;
+            double const sourceOffset = random::stratifiedUnitOffset(baseSeed);
+            unsigned const spectrumPhase
+                = random::stratifiedSpectrumPhase(baseSeed, static_cast<unsigned>(experiment.sigmaA.size()));
+            std::vector<ForwardPhiAseRawResult> partials(activeDevices);
+            unsigned rayOffset = 0u;
+            for(unsigned deviceIndex = 0u; deviceIndex < activeDevices; ++deviceIndex)
+            {
+                unsigned const localRayCount
+                    = deviceIndex + 1u == activeDevices ? raysPerDevice + remainder : raysPerDevice;
+                m_deviceContexts[deviceIndex]->begin(
+                    deviceIndex == 0u ? primaryMeshView(betaVolume) : m_meshes[deviceIndex].toView(),
+                    localRayCount,
+                    random::seedForWorker(baseSeed, 0u, deviceIndex),
+                    rayOffset,
+                    rayCount,
+                    sourceOffset,
+                    spectrumPhase,
+                    betaVolumeTotal,
+                    experiment,
+                    resetAccumulators);
+                rayOffset += localRayCount;
+            }
+            for(unsigned deviceIndex = 0u; deviceIndex < activeDevices; ++deviceIndex)
+            {
+                m_deviceContexts[deviceIndex]->finish(
+                    partials[deviceIndex],
+                    runtimes[deviceIndex],
+                    downloadAccumulators);
+                mergeForwardRawResult(combined, partials[deviceIndex]);
+            }
+            if(combined.rayCount != accumulatedRayCount)
+                throw std::runtime_error("Forward ray partition accounting mismatch.");
+            return combined;
+        }
+
+        [[nodiscard]] DeviceMeshView primaryMeshView(auto const& betaVolume) const
+        {
+            auto mesh = m_meshes.front().toView();
+            mesh.betaVolume = std::span<double const>(betaVolume.data(), betaVolume.getMdSpan().getExtents().x());
+            return mesh;
+        }
+
+        void refreshDynamicMeshes(
+            auto const& betaVolume,
+            HostMesh& hostMesh,
+            bool requireHostValues,
+            bool synchronizePrimaryMesh)
+        {
+            m_betaVolumeTotal = m_deviceContexts.front()->rebuildBetaVolumePrefix(m_meshes.front(), betaVolume);
+            if(m_meshes.size() == 1u && !requireHostValues)
+            {
+                return;
+            }
+
+            auto queue = m_meshes.front().m_device.makeQueue(alpaka::queueKind::blocking);
+            hostMesh.setBetaVolume(detail::copyToVector(queue, betaVolume));
+            if(synchronizePrimaryMesh)
+                detail::copyVectorToBuffer(queue, hostMesh.betaVolume, m_meshes.front().betaVolume);
+            for(std::size_t index = 1u; index < m_meshes.size(); ++index)
+            {
+                auto& mesh = m_meshes[index];
+                auto secondaryQueue = mesh.m_device.makeQueue(alpaka::queueKind::blocking);
+                detail::copyVectorToBuffer(secondaryQueue, hostMesh.betaVolume, mesh.betaVolume);
+                m_deviceContexts[index]->rebuildBetaVolumePrefix(mesh, mesh.betaVolume);
+            }
+        }
+
+        T_Executor m_executor;
+        std::vector<DeviceMeshContainer<T_Device>> m_meshes;
+        std::vector<std::unique_ptr<ForwardPhiAseDeviceContext<T_Device, T_Executor>>> m_deviceContexts;
+        double m_betaVolumeTotal = 0.0;
+    };
+} // namespace hase::core

--- a/include/core/forwardPhiAseUtilities.hpp
+++ b/include/core/forwardPhiAseUtilities.hpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Tim Hanel
+ *
+ * This file is part of HASEonGPU
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <core/mesh.hpp>
+#include <core/types.hpp>
+#include <random/random.hpp>
+
+namespace hase::core
+{
+    inline double calcVolumeDndtAse(
+        HostMesh const& mesh,
+        double const sigmaA,
+        double const sigmaE,
+        float const phiAse,
+        unsigned const volume)
+    {
+        double const gainPerDensity = mesh.betaVolume[volume] * (sigmaE + sigmaA) - sigmaA;
+        return gainPerDensity * phiAse;
+    }
+
+    inline unsigned baseRngSeed(ComputeParameters const& compute)
+    {
+        if(compute.rngSeed == ComputeParameters::unspecifiedRngSeed)
+            return random::SeedGenerator::get().getSeed();
+        return compute.rngSeed;
+    }
+} // namespace hase::core

--- a/include/core/forwardSrm.hpp
+++ b/include/core/forwardSrm.hpp
@@ -15,6 +15,8 @@
 #include <kernels/forward/accumulation.hpp>
 
 #include <limits>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace hase::core
@@ -31,6 +33,77 @@ namespace hase::core
         double srmRemainingFraction = 0.0;
         unsigned srmMaxIterations = 0u;
         unsigned srmDivergenceStreak = 0u;
+    };
+
+    template<alpaka::onHost::concepts::Device T_Device>
+    class ForwardSrmWorkspace
+    {
+        using T_DoubleBuffer = ALPAKA_TYPEOF(alpaka::onHost::alloc<double>(std::declval<T_Device&>(), unsigned{1}));
+        using T_UnsignedBuffer
+            = ALPAKA_TYPEOF(alpaka::onHost::alloc<unsigned>(std::declval<T_Device&>(), unsigned{1}));
+        using T_CharBuffer = ALPAKA_TYPEOF(alpaka::onHost::alloc<char>(std::declval<T_Device&>(), unsigned{1}));
+
+    public:
+        ForwardSrmWorkspace(T_Device& device, unsigned faceCount, unsigned reservoirSize, unsigned maxRayCount)
+            : countsA(alpaka::onHost::alloc<unsigned>(device, faceCount))
+            , countsB(alpaka::onHost::alloc<unsigned>(device, faceCount))
+            , dirXA(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , dirXB(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , dirYA(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , dirYB(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , dirZA(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , dirZB(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , weightsA(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , weightsB(alpaka::onHost::alloc<double>(device, faceCount * reservoirSize))
+            , sigmaIndicesA(alpaka::onHost::alloc<unsigned>(device, faceCount * reservoirSize))
+            , sigmaIndicesB(alpaka::onHost::alloc<unsigned>(device, faceCount * reservoirSize))
+            , faceWeightsA(alpaka::onHost::alloc<double>(device, faceCount))
+            , faceWeightsB(alpaka::onHost::alloc<double>(device, faceCount))
+            , samplingCdf(alpaka::onHost::alloc<double>(device, faceCount))
+            , samplingTotalWeight(alpaka::onHost::alloc<double>(device, 1u))
+            , systematicOffset(alpaka::onHost::alloc<double>(device, 1u))
+            , stratifiedRayCounts(alpaka::onHost::alloc<unsigned>(device, faceCount))
+            , stratifiedRayOffsets(alpaka::onHost::alloc<unsigned>(device, faceCount))
+            , stratifiedRayFaces(alpaka::onHost::alloc<unsigned>(device, maxRayCount))
+            , samplingCdfScanBuffer(
+                  alpaka::onHost::alloc<char>(
+                      device,
+                      alpaka::onHost::getScanBufferSize<double>(alpaka::Vec{faceCount})))
+            , stratifiedCountScanBuffer(
+                  alpaka::onHost::alloc<char>(
+                      device,
+                      alpaka::onHost::getScanBufferSize<unsigned>(alpaka::Vec{faceCount})))
+            , faceCount(faceCount)
+            , reservoirSize(reservoirSize)
+            , maxRayCount(maxRayCount)
+        {
+        }
+
+        T_UnsignedBuffer countsA;
+        T_UnsignedBuffer countsB;
+        T_DoubleBuffer dirXA;
+        T_DoubleBuffer dirXB;
+        T_DoubleBuffer dirYA;
+        T_DoubleBuffer dirYB;
+        T_DoubleBuffer dirZA;
+        T_DoubleBuffer dirZB;
+        T_DoubleBuffer weightsA;
+        T_DoubleBuffer weightsB;
+        T_UnsignedBuffer sigmaIndicesA;
+        T_UnsignedBuffer sigmaIndicesB;
+        T_DoubleBuffer faceWeightsA;
+        T_DoubleBuffer faceWeightsB;
+        T_DoubleBuffer samplingCdf;
+        T_DoubleBuffer samplingTotalWeight;
+        T_DoubleBuffer systematicOffset;
+        T_UnsignedBuffer stratifiedRayCounts;
+        T_UnsignedBuffer stratifiedRayOffsets;
+        T_UnsignedBuffer stratifiedRayFaces;
+        T_CharBuffer samplingCdfScanBuffer;
+        T_CharBuffer stratifiedCountScanBuffer;
+        unsigned faceCount;
+        unsigned reservoirSize;
+        unsigned maxRayCount;
     };
 
     template<alpaka::onHost::concepts::Device T_Device, alpaka::concepts::Executor T_Exec>
@@ -54,44 +127,38 @@ namespace hase::core
         alpaka::concepts::IBuffer auto const& sigmaE,
         unsigned const lambdaResolution,
         unsigned const threadLocalStridingRNG,
-        SrmControls const srmControls)
+        SrmControls const srmControls,
+        ForwardSrmWorkspace<T_Device>& workspace)
     {
         auto accumulationSpans
             = hase::kernels::forward::ForwardAccumulationSpans{phi, phiSquare, volumeRayVisits, droppedRays};
         auto spectrumSpans = hase::kernels::forward::ForwardSpectrumSpans{sigmaA, sigmaE, lambdaResolution};
         unsigned const faceCount = mesh.numberOfCells * mesh.numberOfFacesPerCell;
-        unsigned const reservoirSlots = faceCount * experiment.surfaceReservoirSize;
-        alpaka::concepts::IBuffer auto countsA = alpaka::onHost::alloc<unsigned>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto countsB = alpaka::onHost::alloc<unsigned>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto dirXA = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto dirXB = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto dirYA = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto dirYB = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto dirZA = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto dirZB = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto weightsA = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto weightsB = alpaka::onHost::alloc<double>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto sigmaIndicesA
-            = alpaka::onHost::alloc<unsigned>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto sigmaIndicesB
-            = alpaka::onHost::alloc<unsigned>(devBundle.device, reservoirSlots);
-        alpaka::concepts::IBuffer auto faceWeightsA = alpaka::onHost::alloc<double>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto faceWeightsB = alpaka::onHost::alloc<double>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto samplingCdf = alpaka::onHost::alloc<double>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto samplingTotalWeight = alpaka::onHost::alloc<double>(devBundle.device, 1u);
-        alpaka::concepts::IBuffer auto systematicOffset = alpaka::onHost::alloc<double>(devBundle.device, 1u);
-        alpaka::concepts::IBuffer auto stratifiedRayCounts
-            = alpaka::onHost::alloc<unsigned>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto stratifiedRayOffsets
-            = alpaka::onHost::alloc<unsigned>(devBundle.device, faceCount);
-        alpaka::concepts::IBuffer auto stratifiedRayFaces
-            = alpaka::onHost::alloc<unsigned>(devBundle.device, rayCount);
-        alpaka::concepts::IBuffer auto samplingCdfScanBuffer = alpaka::onHost::alloc<char>(
-            devBundle.device,
-            alpaka::onHost::getScanBufferSize<double>(alpaka::Vec{faceCount}));
-        alpaka::concepts::IBuffer auto stratifiedCountScanBuffer = alpaka::onHost::alloc<char>(
-            devBundle.device,
-            alpaka::onHost::getScanBufferSize<unsigned>(alpaka::Vec{faceCount}));
+        if(workspace.faceCount != faceCount || workspace.reservoirSize != experiment.surfaceReservoirSize
+           || rayCount > workspace.maxRayCount)
+            throw std::runtime_error("persistent forward SRM workspace does not match this launch");
+        auto& countsA = workspace.countsA;
+        auto& countsB = workspace.countsB;
+        auto& dirXA = workspace.dirXA;
+        auto& dirXB = workspace.dirXB;
+        auto& dirYA = workspace.dirYA;
+        auto& dirYB = workspace.dirYB;
+        auto& dirZA = workspace.dirZA;
+        auto& dirZB = workspace.dirZB;
+        auto& weightsA = workspace.weightsA;
+        auto& weightsB = workspace.weightsB;
+        auto& sigmaIndicesA = workspace.sigmaIndicesA;
+        auto& sigmaIndicesB = workspace.sigmaIndicesB;
+        auto& faceWeightsA = workspace.faceWeightsA;
+        auto& faceWeightsB = workspace.faceWeightsB;
+        auto& samplingCdf = workspace.samplingCdf;
+        auto& samplingTotalWeight = workspace.samplingTotalWeight;
+        auto& systematicOffset = workspace.systematicOffset;
+        auto& stratifiedRayCounts = workspace.stratifiedRayCounts;
+        auto& stratifiedRayOffsets = workspace.stratifiedRayOffsets;
+        auto& stratifiedRayFaces = workspace.stratifiedRayFaces;
+        auto& samplingCdfScanBuffer = workspace.samplingCdfScanBuffer;
+        auto& stratifiedCountScanBuffer = workspace.stratifiedCountScanBuffer;
         auto reservoirSpansA = hase::kernels::forward::SurfaceReservoirSpans{
             countsA,
             dirXA,

--- a/include/core/mesh.hpp
+++ b/include/core/mesh.hpp
@@ -170,7 +170,6 @@ namespace hase::core
         float crystalTFluo;
         unsigned claddingNumber;
         unsigned numberOfCells;
-        unsigned numberOfPrisms;
         unsigned numberOfPoints;
         unsigned numberOfSamples;
         unsigned numberOfFacesPerCell;
@@ -401,7 +400,6 @@ namespace hase::core
             , crystalTFluo(crystalTFluo)
             , claddingNumber(claddingNumber)
             , numberOfCells(numberOfCells)
-            , numberOfPrisms(numberOfCells)
             , numberOfPoints(numberOfPoints)
             , numberOfSamples(numberOfSamples)
             , numberOfFacesPerCell(numberOfFacesPerCell)
@@ -451,7 +449,6 @@ namespace hase::core
                 crystalTFluo,
                 claddingNumber,
                 numberOfCells,
-                numberOfCells,
                 numberOfPoints,
                 numberOfSamples,
                 numberOfFacesPerCell,
@@ -499,7 +496,6 @@ namespace hase::core
         float crystalTFluo;
         unsigned claddingNumber;
         unsigned numberOfCells;
-        unsigned numberOfPrisms;
         unsigned numberOfPoints;
         unsigned numberOfSamples;
         unsigned numberOfFacesPerCell;
@@ -546,7 +542,6 @@ namespace hase::core
         unsigned claddingNumber = 1u;
         double claddingAbsorption = 0.0;
         unsigned numberOfCells = 0u;
-        unsigned numberOfPrisms = 0u;
         unsigned numberOfMeshPoints = 0u;
         unsigned numberOfPoints = 0u;
         unsigned numberOfSamples = 0u;
@@ -608,7 +603,6 @@ namespace hase::core
             , claddingNumber(claddingNumber)
             , claddingAbsorption(claddingAbsorption)
             , numberOfCells(static_cast<unsigned>(this->cellTypes.size()))
-            , numberOfPrisms(numberOfCells)
             , numberOfMeshPoints(static_cast<unsigned>(this->points.size() / 3u))
             , numberOfPoints(
                   structuredNumberOfPoints == 0u ? static_cast<unsigned>(this->samplePoints.size() / 3u)

--- a/include/core/simulation.hpp
+++ b/include/core/simulation.hpp
@@ -9,7 +9,6 @@
 
 #include <algorithm> /* std::max */
 #include <chrono> /* std::chrono::system_clock */
-#include <cstdlib> /* getenv, strtoul */
 #include <ctime> /* time */
 #include <locale> /* std::locale */
 #include <numeric> /* accumulate*/
@@ -22,112 +21,18 @@
 #include <alpaka/alpaka.hpp>
 
 #include <alpakaUtils/DevBundle.hpp>
+#include <alpakaUtils/backendNames.hpp>
 #include <core/SerialVersion.hpp>
-#include <core/calcForwardPhiAse.hpp>
-#include <core/calcPhiAseThreaded.hpp>
+#include <core/forwardPhiAseEvaluator.hpp>
+#include <core/forwardPhiAseUtilities.hpp>
 #include <core/logging.hpp>
 #include <core/mesh.hpp>
 #include <core/types.hpp>
-#include <random/random.hpp>
 #include <utils/ray_histogram.hpp>
 #include <utils/writeToVtk.hpp>
-#if !defined(DISABLE_MPI) && defined(MPI_FOUND)
-#    include <core/calcPhiAseMpi.hpp>
-#endif
 
 namespace hase::core
 {
-
-    inline double calcVolumeDndtAse(
-        HostMesh const& mesh,
-        double const sigmaA,
-        double const sigmaE,
-        float const phiAse,
-        unsigned const volume)
-    {
-        double const gainPerDensity = mesh.betaVolume[volume] * (sigmaE + sigmaA) - sigmaA;
-        return gainPerDensity * phiAse;
-    }
-
-    inline unsigned baseRngSeed(ComputeParameters const& compute)
-    {
-        if(compute.rngSeed == ComputeParameters::unspecifiedRngSeed)
-        {
-            return random::SeedGenerator::get().getSeed();
-        }
-        return compute.rngSeed;
-    }
-
-    std::string getNameForBackend(auto const& backend, auto const& device)
-    {
-        std::string backendName;
-        backendName += alpaka::onHost::getName(alpaka::getApi(device)) + "_";
-        backendName += alpaka::onHost::getName(alpaka::getDeviceKind(device)) + "_";
-        backendName += alpaka::onHost::getName(backend[alpaka::object::exec]);
-        return backendName;
-    }
-
-    static std::vector<std::string> backendList()
-    {
-        auto backends = alpaka::onHost::allBackends(alpaka::onHost::enabledApis, alpaka::exec::enabledExecutors);
-        std::vector<std::string> list;
-        alpaka::onHost::executeForEachIfHasDevice(
-            [&](auto const& backend) -> int
-            {
-                auto devSelector = alpaka::onHost::makeDeviceSelector(backend[alpaka::object::deviceSpec]);
-                auto sampleDevice = devSelector.makeDevice(0);
-                list.emplace_back(getNameForBackend(backend, sampleDevice));
-                return 0;
-            },
-            backends);
-        return list;
-    }
-
-    inline unsigned envUnsigned(char const* name, unsigned fallback = 0)
-    {
-        char const* value = std::getenv(name);
-        if(value == nullptr || *value == '\0')
-        {
-            return fallback;
-        }
-
-        char* end = nullptr;
-        unsigned long parsed = std::strtoul(value, &end, 10);
-        return end == value ? fallback : static_cast<unsigned>(parsed);
-    }
-
-    inline RuntimeTopology detectRuntimeTopology()
-    {
-        RuntimeTopology topology;
-
-        unsigned const worldSize = envUnsigned(
-            "OMPI_COMM_WORLD_SIZE",
-            envUnsigned("PMI_SIZE", envUnsigned("PMIX_SIZE", envUnsigned("SLURM_NTASKS", 1))));
-        unsigned const localSize = std::max(
-            1u,
-            envUnsigned(
-                "OMPI_COMM_WORLD_LOCAL_SIZE",
-                envUnsigned("MPI_LOCALNRANKS", envUnsigned("MV2_COMM_WORLD_LOCAL_SIZE", 1))));
-        unsigned const slurmNodes = envUnsigned("SLURM_JOB_NUM_NODES", 0);
-        unsigned const activeNodes
-            = slurmNodes > 0 ? slurmNodes : std::max(1u, (worldSize + localSize - 1u) / localSize);
-
-        topology.activeNodes = activeNodes;
-        topology.activeRanks = worldSize;
-        topology.avgActiveRanksPerNode = static_cast<double>(worldSize) / static_cast<double>(activeNodes);
-        topology.minActiveRanksPerNode = localSize;
-        topology.maxActiveRanksPerNode = localSize;
-        return topology;
-    }
-
-    bool isSelected(auto const& backend, auto const& device, ComputeParameters& compute)
-    {
-        if(getNameForBackend(backend, device) == compute.backend)
-        {
-            return true;
-        }
-        return false;
-    }
 
     template<bool MATLAB>
     int startSimulation(
@@ -161,7 +66,7 @@ namespace hase::core
                 }
                 using T_Device = ALPAKA_TYPEOF(devSelector.makeDevice(0));
                 T_Device sampleDevice = devSelector.makeDevice(0);
-                if(!isSelected(backend, sampleDevice, compute))
+                if(hase::alpakaUtils::getNameForBackend(backend, sampleDevice) != compute.backend)
                 {
                     return 0;
                 }
@@ -176,137 +81,30 @@ namespace hase::core
                 }
                 compute.devices.resize(compute.numDevices);
 
-                std::vector<DeviceMeshContainer<T_Device>> meshes;
+                std::vector<T_Device> devices;
+                devices.reserve(compute.devices.size());
                 for(auto const& gpu_i : compute.devices)
-                {
-                    // use the first device
-                    alpaka::onHost::Device device = devSelector.makeDevice(gpu_i);
-                    meshes.emplace_back(hostMesh.toDevice(device));
-                }
+                    devices.emplace_back(devSelector.makeDevice(gpu_i));
 
                 oneDidRun = true;
                 // Statistics data
-                float runtime = 0.0;
                 double maxRelativeStandardError = 0;
                 double avgRelativeStandardError = 0;
                 unsigned highRelativeStandardError = 0;
                 unsigned definedRelativeStandardErrors = 0;
                 time_t starttime = time(0);
-                unsigned maxDevices = compute.devices.size();
-                std::vector runtimes(maxDevices, 0.f);
-                unsigned usedGPUs = 0;
-                RuntimeTopology topology;
-                if(!experiment.isForwardPropagation())
-                {
-                    throw std::runtime_error("Only forward volume propagation is supported by the openPMD backend.");
-                }
-
-                ForwardPhiAseRawResult rawResult;
-                unsigned adaptiveLaunches = 0u;
-                std::vector<unsigned> convergenceRayCounts;
-                if(compute.parallelMode == ParallelMode::SINGLE)
-                {
-                    unsigned const rngSeed = baseRngSeed(compute);
-                    for(unsigned completedIncreases = 0u;; ++completedIncreases)
-                    {
-                        unsigned const targetRayCount = adaptiveRayTarget(experiment, compute, completedIncreases);
-                        unsigned const batchRayCount = targetRayCount - rawResult.rayCount;
-                        unsigned const activeDevices = std::min(maxDevices, batchRayCount);
-                        if(batchRayCount == 0u)
-                        {
-                            if(targetRayCount == experiment.maxRays || experiment.forwardRayCount != 0u)
-                            {
-                                break;
-                            }
-                            continue;
-                        }
-                        if(activeDevices == 0u)
-                        {
-                            break;
-                        }
-
-                        std::fill(runtimes.begin(), runtimes.end(), 0.0f);
-                        ForwardPhiAseRawResult const batchResult = calcForwardPhiAseOnDevices(
-                            exec,
-                            experiment,
-                            compute,
-                            hostMesh,
-                            meshes,
-                            0u,
-                            activeDevices,
-                            batchRayCount,
-                            0u,
-                            batchRayCount,
-                            random::seedForAdaptiveLaunch(rngSeed, adaptiveLaunches),
-                            0u,
-                            runtimes);
-                        mergeForwardRawResult(rawResult, batchResult);
-                        runtime += *std::ranges::max_element(runtimes);
-                        usedGPUs = std::max(usedGPUs, activeDevices);
-                        ++adaptiveLaunches;
-                        finalizeForwardPhiAse(hostMesh, rawResult, result);
-                        recordAdaptiveRayConvergence(
-                            result,
-                            targetRayCount,
-                            experiment.relativeStandardErrorThreshold,
-                            convergenceRayCounts);
-
-                        if(experiment.forwardRayCount != 0u || targetRayCount == experiment.maxRays
-                           || forwardResultMeetsRelativeStandardError(
-                               result,
-                               experiment.relativeStandardErrorThreshold))
-                        {
-                            break;
-                        }
-                    }
-                    topology = RuntimeTopology{};
-                    topology.activeNodes = 1u;
-                    topology.activeRanks = 1u;
-                    topology.avgActiveRanksPerNode = 1.0;
-                    topology.minActiveRanksPerNode = 1u;
-                    topology.maxActiveRanksPerNode = 1u;
-                    topology.activeGpus = usedGPUs;
-                    topology.avgGpusPerRank = static_cast<double>(usedGPUs);
-                    topology.avgGpusPerNode = static_cast<double>(usedGPUs);
-                    topology.minGpusPerNode = usedGPUs;
-                    topology.maxGpusPerNode = usedGPUs;
-                }
-                else if(compute.parallelMode == ParallelMode::MPI)
-                {
-#if defined(MPI_FOUND) && !defined(DISABLE_MPI)
-                    usedGPUs = hase::core::calcForwardPhiAseMPI(
-                        exec,
-                        experiment,
-                        compute,
-                        hostMesh,
-                        meshes,
-                        rawResult,
-                        topology,
-                        runtime,
-                        adaptiveLaunches,
-                        convergenceRayCounts);
-#else
-#    if !defined(MPI_FOUND)
-                    dout(V_ERROR) << "Did not find MPI on your system!";
-                    exit(1);
-#    else
-                    dout(V_ERROR) << "TURN 'DISABLE_MPI' to 'OFF' in order to run PhiASE on multiple nodes!";
-                    exit(1);
-#    endif
-#endif
-                }
-
-                else
-                {
-                    dout(V_ERROR) << "No valid parallel-mode for GPU!" << std::endl;
-                    exit(1);
-                }
+                ForwardPhiAseContext context{std::move(devices), exec, experiment, hostMesh};
+                auto evaluation
+                    = context.evaluate(experiment, compute, hostMesh, context.primaryBetaVolume(), result, false);
+                float const runtime = evaluation.runtime;
+                unsigned const usedGPUs = evaluation.usedDevices;
+                RuntimeTopology const& topology = evaluation.topology;
+                unsigned const rayCount = evaluation.rayCount;
+                unsigned const adaptiveLaunches = evaluation.adaptiveLaunches;
+                auto const& convergenceRayCounts = evaluation.convergenceRayCounts;
 
                 if(usedGPUs == 0)
-                {
-                    return 0;
-                }
-                finalizeForwardPhiAse(hostMesh, rawResult, result);
+                    throw std::runtime_error("forward ASE evaluator used no devices");
 
                 dout(V_INFO) << "Active nodes             : " << topology.activeNodes << std::endl;
                 dout(V_INFO) << "Active ranks             : " << topology.activeRanks << std::endl;
@@ -319,19 +117,6 @@ namespace hase::core
                              << " avg (min=" << topology.minGpusPerNode << ", max=" << topology.maxGpusPerNode << ")"
                              << std::endl;
 
-                for(unsigned volume = 0u; volume < result.phiAse.size() && volume < hostMesh.betaVolume.size();
-                    ++volume)
-                {
-                    double const fluorescenceRate = hostMesh.nTot / hostMesh.crystalTFluo;
-                    result.phiAse.at(volume) *= fluorescenceRate;
-                    result.standardError.at(volume) *= fluorescenceRate;
-                    result.dndtAse.at(volume) = calcVolumeDndtAse(
-                        hostMesh,
-                        experiment.maxSigmaA,
-                        experiment.maxSigmaE,
-                        result.phiAse.at(volume),
-                        volume);
-                }
                 /***************************************************************************
                  * PRINT SOLUTION
                  **************************************************************************/
@@ -369,7 +154,7 @@ namespace hase::core
                         hostMesh,
                         result.dndtAse,
                         vtkPath / fs::path("dndt_" + currentTime + ".vtk"),
-                        rawResult.rayCount,
+                        rayCount,
                         experiment.maxRays,
                         experiment.relativeStandardErrorThreshold,
                         experiment.useReflections,
@@ -379,7 +164,7 @@ namespace hase::core
                         hostMesh,
                         tmpPhiAse,
                         vtkPath / fs::path("phiase_" + currentTime + ".vtk"),
-                        rawResult.rayCount,
+                        rayCount,
                         experiment.maxRays,
                         experiment.relativeStandardErrorThreshold,
                         experiment.useReflections,
@@ -389,7 +174,7 @@ namespace hase::core
                         hostMesh,
                         result.standardError,
                         vtkPath / fs::path("standard_error_" + currentTime + ".vtk"),
-                        rawResult.rayCount,
+                        rayCount,
                         experiment.maxRays,
                         experiment.relativeStandardErrorThreshold,
                         experiment.useReflections,
@@ -399,7 +184,7 @@ namespace hase::core
                         hostMesh,
                         tmpTotalRays,
                         vtkPath / fs::path("total_rays_" + currentTime + ".vtk"),
-                        rawResult.rayCount,
+                        rayCount,
                         experiment.maxRays,
                         experiment.relativeStandardErrorThreshold,
                         experiment.useReflections,
@@ -409,7 +194,7 @@ namespace hase::core
                         hostMesh,
                         result.relativeStandardError,
                         vtkPath / fs::path("relative_standard_error_" + currentTime + ".vtk"),
-                        rawResult.rayCount,
+                        rayCount,
                         experiment.maxRays,
                         experiment.relativeStandardErrorThreshold,
                         experiment.useReflections,
@@ -459,22 +244,21 @@ namespace hase::core
                     dout(V_STAT) << "Backend       : " << compute.backend << std::endl;
                     dout(V_STAT) << "RNG Seed      : " << baseRngSeed(compute) << std::endl;
                     dout(V_STAT) << "ParallelMode      : " << compute.parallelMode << std::endl;
-                    dout(V_STAT) << "Prisms            : " << meshes[0].numberOfPrisms << std::endl;
+                    dout(V_STAT) << "Cells             : " << context.primaryMesh().numberOfCells << std::endl;
                     dout(V_STAT) << "Samples           : "
                                  << std::min(static_cast<unsigned>(result.dndtAse.size()), numSamples) << std::endl;
                     if(experiment.forwardRayCount != 0u)
                     {
-                        dout(V_STAT) << "Forward rays      : " << rawResult.rayCount << " (explicit)" << std::endl;
+                        dout(V_STAT) << "Forward rays      : " << rayCount << " (explicit)" << std::endl;
                     }
                     else if(experiment.maxRays > experiment.minRays)
                     {
-                        dout(V_STAT) << "Forward rays      : " << rawResult.rayCount << " of " << experiment.minRays
-                                     << " - " << experiment.maxRays << " (" << adaptiveLaunches << " launches)"
-                                     << std::endl;
+                        dout(V_STAT) << "Forward rays      : " << rayCount << " of " << experiment.minRays << " - "
+                                     << experiment.maxRays << " (" << adaptiveLaunches << " launches)" << std::endl;
                     }
                     else
                     {
-                        dout(V_STAT) << "Forward rays      : " << rawResult.rayCount << std::endl;
+                        dout(V_STAT) << "Forward rays      : " << rayCount << std::endl;
                     }
                     dout(V_STAT) << "sum(totalRays)    : "
                                  << std::accumulate(result.totalRays.begin(), result.totalRays.end(), 0.) << std::endl;
@@ -499,7 +283,7 @@ namespace hase::core
                     dout(V_STAT) << "=== Adaptive forward-ray convergence by cell (green: RSE target reached; red: "
                                     "budget exhausted) ==="
                                  << std::endl;
-                    hase::utils::ray_histogram(convergenceRayCounts, rawResult.rayCount);
+                    hase::utils::ray_histogram(convergenceRayCounts, rayCount);
                     dout(V_STAT) << std::endl;
                 }
                 // Cleanup device memory
@@ -515,7 +299,7 @@ namespace hase::core
             std::cout << " Backend did not match any available backend with available device! \n Available backend "
                          "specifications are: "
                       << std::endl;
-            for(auto const& element : backendList())
+            for(auto const& element : hase::alpakaUtils::availableBackendNames())
             {
                 std::cout << element << "\n";
             }

--- a/include/core/simulationRunControl.hpp
+++ b/include/core/simulationRunControl.hpp
@@ -79,6 +79,38 @@ namespace hase::core
         double implicitTolerance = 1.0e-10;
     };
 
+    struct SimulationExecutionMode
+    {
+        static inline std::string const AUTONOMOUS = "autonomous";
+        static inline std::string const SYNCHRONIZED_DEBUG = "synchronized-debug";
+    };
+
+    struct SimulationOutputField
+    {
+        static inline std::string const BETA_VOLUME = "beta_volume";
+        static inline std::string const PHI_ASE = "phi_ase";
+        static inline std::string const STANDARD_ERROR = "standard_error";
+        static inline std::string const RELATIVE_STANDARD_ERROR = "relative_standard_error";
+        static inline std::string const TOTAL_RAYS = "total_rays";
+        static inline std::string const DNDT_ASE = "dndt_ase";
+        static inline std::string const DNDT_PUMP = "dndt_pump";
+
+        [[nodiscard]] static std::vector<std::string> all()
+        {
+            return {BETA_VOLUME, PHI_ASE, STANDARD_ERROR, RELATIVE_STANDARD_ERROR, TOTAL_RAYS, DNDT_ASE, DNDT_PUMP};
+        }
+    };
+
+    struct SimulationControlField
+    {
+        static inline std::string const BETA_VOLUME = "beta_volume";
+
+        [[nodiscard]] static std::vector<std::string> all()
+        {
+            return {BETA_VOLUME};
+        }
+    };
+
     struct SimulationRunControl
     {
         double timeStep = 0.0;
@@ -86,6 +118,10 @@ namespace hase::core
         bool enableAse = true;
         bool prePump = false;
         unsigned pumpSteps = std::numeric_limits<unsigned>::max();
+        std::string executionMode = SimulationExecutionMode::AUTONOMOUS;
+        std::vector<unsigned> outputSteps;
+        std::vector<std::string> outputFields = SimulationOutputField::all();
+        std::vector<std::string> controlFields;
         TimeIntegrationParameters timeIntegration;
         PumpParameters pump;
     };

--- a/include/core/simulationSnapshot.hpp
+++ b/include/core/simulationSnapshot.hpp
@@ -9,6 +9,8 @@
 
 #include <core/types.hpp>
 
+#include <algorithm>
+#include <string>
 #include <vector>
 
 namespace hase::core
@@ -21,5 +23,11 @@ namespace hase::core
         Result aseResult;
         std::vector<double> dndtPump;
         std::vector<double> dndtAse;
+        std::vector<std::string> fields;
+
+        [[nodiscard]] bool contains(std::string const& field) const
+        {
+            return std::ranges::find(fields, field) != fields.end();
+        }
     };
 } // namespace hase::core

--- a/include/core/timeSteppedSimulation.hpp
+++ b/include/core/timeSteppedSimulation.hpp
@@ -10,9 +10,12 @@
 #include <alpaka/alpaka.hpp>
 
 #include <alpakaUtils/DevBundle.hpp>
+#include <alpakaUtils/backendNames.hpp>
 #include <alpakaUtils/memory.hpp>
 #include <alpakaUtils/utils.hpp>
-#include <core/simulation.hpp>
+#include <core/forwardPhiAseEvaluator.hpp>
+#include <core/logging.hpp>
+#include <core/mesh.hpp>
 #include <core/simulationRunControl.hpp>
 #include <core/simulationSnapshot.hpp>
 #include <core/types.hpp>
@@ -23,6 +26,8 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
+#include <memory>
+#include <numeric>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -32,17 +37,7 @@ namespace hase::core
 {
     namespace detail
     {
-        template<typename T_Buffer>
-        std::vector<typename T_Buffer::value_type> copyToVector(auto const& queue, T_Buffer const& buffer)
-        {
-            auto hostBuffer = alpaka::onHost::allocHostLike(buffer);
-            alpaka::onHost::memcpy(queue, hostBuffer, buffer);
-            alpaka::onHost::wait(queue);
-            auto const* data = alpaka::onHost::data(hostBuffer);
-            return {data, data + buffer.getExtents().product()};
-        }
-
-        double absorptionAtEmissionPeak(ExperimentParameters const& experiment)
+        inline double absorptionAtEmissionPeak(ExperimentParameters const& experiment)
         {
             if(experiment.sigmaA.empty() || experiment.sigmaE.empty())
             {
@@ -53,7 +48,7 @@ namespace hase::core
             return experiment.sigmaA.at(std::min(index, experiment.sigmaA.size() - 1u));
         }
 
-        std::vector<double> makeLumpedPointVolumes(HostMesh const& mesh)
+        inline std::vector<double> makeLumpedPointVolumes(HostMesh const& mesh)
         {
             std::vector<double> volumes(mesh.numberOfMeshPoints, 0.0);
             for(unsigned cell = 0u; cell < mesh.numberOfCells; ++cell)
@@ -69,7 +64,7 @@ namespace hase::core
             return volumes;
         }
 
-        void validateRunParameters(SimulationRunControl const& run)
+        inline void validateRunParameters(SimulationRunControl const& run)
         {
             if(run.timeStep <= 0.0)
             {
@@ -78,6 +73,58 @@ namespace hase::core
             if(run.numberOfSteps == 0u)
             {
                 throw std::runtime_error("simulation number_of_steps must be positive");
+            }
+            if(run.executionMode != SimulationExecutionMode::AUTONOMOUS
+               && run.executionMode != SimulationExecutionMode::SYNCHRONIZED_DEBUG)
+            {
+                throw std::runtime_error("simulation execution_mode must be autonomous or synchronized-debug");
+            }
+            unsigned previousOutputStep = 0u;
+            for(unsigned outputStep : run.outputSteps)
+            {
+                if(outputStep == 0u || outputStep > run.numberOfSteps)
+                {
+                    throw std::runtime_error(
+                        "simulation output_steps entries must be completed-step indices in [1, number_of_steps]");
+                }
+                if(outputStep <= previousOutputStep)
+                {
+                    throw std::runtime_error("simulation output_steps must be strictly increasing and unique");
+                }
+                previousOutputStep = outputStep;
+            }
+            auto const supportedOutputFields = SimulationOutputField::all();
+            if(run.outputFields.empty())
+            {
+                throw std::runtime_error("simulation output_fields must contain at least one field");
+            }
+            for(std::size_t index = 0u; index < run.outputFields.size(); ++index)
+            {
+                auto const& outputField = run.outputFields[index];
+                if(std::ranges::find(supportedOutputFields, outputField) == supportedOutputFields.end())
+                {
+                    throw std::runtime_error("unsupported simulation output field '" + outputField + "'");
+                }
+                if(std::ranges::find(run.outputFields.begin(), run.outputFields.begin() + index, outputField)
+                   != run.outputFields.begin() + index)
+                {
+                    throw std::runtime_error("simulation output_fields must be unique");
+                }
+            }
+            if(run.executionMode == SimulationExecutionMode::AUTONOMOUS && !run.controlFields.empty())
+                throw std::runtime_error("simulation control_fields require synchronized-debug mode");
+            if(run.executionMode == SimulationExecutionMode::SYNCHRONIZED_DEBUG && !run.outputSteps.empty())
+                throw std::runtime_error(
+                    "synchronized-debug emits every completed step; output_steps must be omitted");
+            auto const supportedControlFields = SimulationControlField::all();
+            for(std::size_t index = 0u; index < run.controlFields.size(); ++index)
+            {
+                auto const& controlField = run.controlFields[index];
+                if(std::ranges::find(supportedControlFields, controlField) == supportedControlFields.end())
+                    throw std::runtime_error("unsupported simulation control field '" + controlField + "'");
+                if(std::ranges::find(run.controlFields.begin(), run.controlFields.begin() + index, controlField)
+                   != run.controlFields.begin() + index)
+                    throw std::runtime_error("simulation control_fields must be unique");
             }
             if(run.pump.schemaVersion != 1u || run.pump.rayCount == 0u || run.pump.sources.empty())
                 throw std::runtime_error("invalid general pump configuration");
@@ -101,51 +148,70 @@ namespace hase::core
 
     public:
         CompiledSimulationRunner(
-            T_Device& device,
+            std::vector<T_Device> devices,
             T_Executor const& executor,
             ExperimentParameters& experiment,
             ComputeParameters& compute,
             SimulationRunControl const& run,
             HostMesh& hostMesh)
-            : m_device(device)
-            , m_queue(device.makeQueue(alpaka::queueKind::blocking))
-            , m_devBundle(device, executor)
+            : m_forwardAseContext(std::move(devices), executor, experiment, hostMesh)
+            , m_device(m_forwardAseContext.primaryDevice())
+            , m_queue(m_device.makeQueue(alpaka::queueKind::blocking))
+            , m_devBundle(m_device, executor)
             , m_experiment(experiment)
             , m_compute(compute)
             , m_run(run)
             , m_hostMesh(hostMesh)
-            , m_meshContainer(hostMesh.toDevice(device))
-            , m_mesh(m_meshContainer.toView())
+            , m_mesh(m_forwardAseContext.primaryMesh().toView())
             , m_beta(hase::alpakaUtils::toDevice(m_queue, hostMesh.betaVolume))
-            , m_betaNext(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_stage(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_phiAse(alpaka::onHost::alloc<float>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_derivative(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_dndtPump(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_dndtAse(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_k1(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_k2(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_k3(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_k4(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
-            , m_cellPumpIntegral(alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_betaNext(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_stage(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_phiAse(alpaka::onHost::alloc<float>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_derivative(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_dndtPump(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_dndtAse(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_k1(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_k2(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_k3(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_k4(alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
+            , m_cellPumpIntegral(
+                  alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfCells)))
             , m_pointPumpIntegral(
-                  alpaka::onHost::alloc<double>(device, static_cast<std::size_t>(m_mesh.numberOfMeshPoints)))
+                  alpaka::onHost::alloc<double>(m_device, static_cast<std::size_t>(m_mesh.numberOfMeshPoints)))
             , m_lumpedPointVolume(hase::alpakaUtils::toDevice(m_queue, detail::makeLumpedPointVolumes(hostMesh)))
         {
             if(hostMesh.betaVolume.size() != hostMesh.numberOfCells)
                 throw std::runtime_error("simulation beta_volume must contain exactly one value per cell");
         }
 
-        void run(std::function<void(SimulationSnapshot const&)> const& callback)
+        void run(
+            std::function<void(SimulationSnapshot const&)> const& callback,
+            std::function<std::vector<double>(unsigned)> const& receiveControl)
         {
             for(unsigned step = 0u; step < m_run.numberOfSteps; ++step)
             {
                 bool const pumpEnabled = step < m_run.pumpSteps;
                 bool const aseEnabled = m_run.enableAse && !(m_run.prePump && step == 0u);
                 advanceOneStep(pumpEnabled, aseEnabled);
-                callback(makeSnapshot(step + 1u));
-                alpaka::onHost::memcpy(m_queue, m_beta, m_betaNext);
-                alpaka::onHost::wait(m_queue);
+                std::swap(m_beta, m_betaNext);
+                unsigned const completedStep = step + 1u;
+                bool const synchronizedDebug = m_run.executionMode == SimulationExecutionMode::SYNCHRONIZED_DEBUG;
+                if(synchronizedDebug || shouldOutput(completedStep))
+                {
+                    callback(makeSnapshot(completedStep));
+                }
+                if(synchronizedDebug && completedStep < m_run.numberOfSteps)
+                {
+                    if(!receiveControl)
+                        throw std::runtime_error("synchronized-debug requires a control receiver");
+                    auto betaVolume = receiveControl(completedStep);
+                    if(includesControl(SimulationControlField::BETA_VOLUME))
+                    {
+                        if(betaVolume.size() != m_mesh.numberOfCells)
+                            throw std::runtime_error("synchronized beta_volume control has the wrong cell count");
+                        detail::copyVectorToBuffer(m_queue, betaVolume, m_beta);
+                    }
+                }
             }
         }
 
@@ -161,25 +227,27 @@ namespace hase::core
 
         void evaluateDerivative(auto& beta, bool pumpEnabled, bool aseEnabled, bool refreshAse = true)
         {
-            m_hostMesh.setBetaVolume(detail::copyToVector(m_queue, beta));
             if(refreshAse)
             {
                 initializeResult(aseEnabled ? 100000.0 : 0.0, m_hostMesh.numberOfCells);
 
                 if(aseEnabled)
                 {
-                    int const result
-                        = hase::core::startSimulation<false>(m_experiment, m_compute, m_lastAseResult, m_hostMesh);
-                    if(result != 0)
-                    {
-                        throw std::runtime_error("ASE evaluation failed with return code " + std::to_string(result));
-                    }
+                    m_phiAseDeviceResident
+                        = m_forwardAseContext.evaluate(m_experiment, m_compute, m_hostMesh, beta, m_lastAseResult)
+                              .deviceResidentPhi;
+                    if(!m_phiAseDeviceResident)
+                        detail::copyVectorToBuffer(m_queue, m_lastAseResult.phiAse, m_phiAse);
                 }
-                auto hostPhiAse = alpaka::makeView(
-                    alpaka::api::host,
-                    m_lastAseResult.phiAse.data(),
-                    alpaka::Vec{m_lastAseResult.phiAse.size()});
-                alpaka::onHost::memcpy(m_queue, m_phiAse, hostPhiAse);
+                else
+                {
+                    m_phiAseDeviceResident = false;
+                    alpaka::onHost::fill(
+                        m_queue,
+                        m_phiAse,
+                        0.0f,
+                        alpaka::Vec{static_cast<std::size_t>(m_mesh.numberOfCells)});
+                }
             }
 
             if(pumpEnabled)
@@ -197,7 +265,8 @@ namespace hase::core
                     m_dndtPump);
             }
 
-            DerivativeBuffers derivativeBuffers{beta, m_phiAse, m_dndtPump, m_dndtAse, m_derivative};
+            auto& activePhiAse = m_phiAseDeviceResident ? m_forwardAseContext.primaryVolumePhiAse() : m_phiAse;
+            DerivativeBuffers derivativeBuffers{beta, activePhiAse, m_dndtPump, m_dndtAse, m_derivative};
             hase::kernels::enqueueComposeDerivative(
                 m_devBundle,
                 m_queue,
@@ -207,7 +276,6 @@ namespace hase::core
                 std::max(static_cast<double>(m_hostMesh.crystalTFluo), std::numeric_limits<double>::min()),
                 pumpEnabled,
                 derivativeBuffers);
-            alpaka::onHost::wait(m_queue);
         }
 
         void advanceOneStep(bool pumpEnabled, bool aseEnabled)
@@ -256,8 +324,6 @@ namespace hase::core
             }
 
             enqueueClip(m_betaNext);
-            alpaka::onHost::wait(m_queue);
-            m_hostMesh.setBetaVolume(detail::copyToVector(m_queue, m_betaNext));
         }
 
         void stepRungeKutta4(bool pumpEnabled, bool aseEnabled)
@@ -320,18 +386,96 @@ namespace hase::core
                 std::vector<double>(resultSize, 0.0));
         }
 
+        [[nodiscard]] bool includes(std::string const& field) const
+        {
+            return std::ranges::find(m_run.outputFields, field) != m_run.outputFields.end();
+        }
+
+        [[nodiscard]] bool includesControl(std::string const& field) const
+        {
+            return std::ranges::find(m_run.controlFields, field) != m_run.controlFields.end();
+        }
+
+        [[nodiscard]] bool shouldOutput(unsigned completedStep)
+        {
+            if(m_run.outputSteps.empty())
+            {
+                return true;
+            }
+            if(m_nextOutputStep >= m_run.outputSteps.size() || m_run.outputSteps[m_nextOutputStep] != completedStep)
+            {
+                return false;
+            }
+            ++m_nextOutputStep;
+            return true;
+        }
+
+        static void copyStatus(Result const& source, Result& target)
+        {
+            target.srmStatus = source.srmStatus;
+            target.srmPasses = source.srmPasses;
+            target.srmRemainingFraction = source.srmRemainingFraction;
+            target.srmMaxIterations = source.srmMaxIterations;
+            target.srmDivergenceStreak = source.srmDivergenceStreak;
+        }
+
         SimulationSnapshot makeSnapshot(unsigned step)
         {
-            auto dndtPump = detail::copyToVector(m_queue, m_dndtPump);
-            auto dndtAse = detail::copyToVector(m_queue, m_dndtAse);
-            m_lastAseResult.dndtAse = dndtAse;
+            std::vector<double> betaVolume;
+            std::vector<double> dndtPump;
+            std::vector<double> dndtAse;
+            Result aseResult;
+            copyStatus(m_lastAseResult, aseResult);
+
+            if(includes(SimulationOutputField::BETA_VOLUME))
+                betaVolume = detail::copyToVector(m_queue, m_beta);
+            bool const includePhiAse = includes(SimulationOutputField::PHI_ASE);
+            bool const includeStandardError = includes(SimulationOutputField::STANDARD_ERROR);
+            bool const includeRelativeStandardError = includes(SimulationOutputField::RELATIVE_STANDARD_ERROR);
+            bool const includeTotalRays = includes(SimulationOutputField::TOTAL_RAYS);
+            if(m_phiAseDeviceResident)
+            {
+                auto deviceResult = m_forwardAseContext.downloadPrimaryResult(
+                    includePhiAse,
+                    includeStandardError,
+                    includeRelativeStandardError,
+                    includeTotalRays);
+                aseResult.phiAse = std::move(deviceResult.phiAse);
+                aseResult.standardError = std::move(deviceResult.standardError);
+                aseResult.relativeStandardError = std::move(deviceResult.relativeStandardError);
+                aseResult.totalRays = std::move(deviceResult.totalRays);
+                aseResult.droppedRays = std::move(deviceResult.droppedRays);
+            }
+            else
+            {
+                if(includePhiAse)
+                    aseResult.phiAse = m_lastAseResult.phiAse;
+                if(includeStandardError)
+                    aseResult.standardError = m_lastAseResult.standardError;
+                if(includeRelativeStandardError)
+                    aseResult.relativeStandardError = m_lastAseResult.relativeStandardError;
+                if(includeTotalRays)
+                {
+                    aseResult.totalRays = m_lastAseResult.totalRays;
+                    aseResult.droppedRays = m_lastAseResult.droppedRays;
+                }
+            }
+            if(includes(SimulationOutputField::DNDT_ASE))
+            {
+                dndtAse = detail::copyToVector(m_queue, m_dndtAse);
+                aseResult.dndtAse = dndtAse;
+            }
+            if(includes(SimulationOutputField::DNDT_PUMP))
+                dndtPump = detail::copyToVector(m_queue, m_dndtPump);
+
             return SimulationSnapshot{
                 step,
                 static_cast<double>(step) * m_run.timeStep,
-                m_hostMesh.betaVolume,
-                m_lastAseResult,
+                std::move(betaVolume),
+                std::move(aseResult),
                 std::move(dndtPump),
-                std::move(dndtAse)};
+                std::move(dndtAse),
+                m_run.outputFields};
         }
 
         void enqueueAddScaled(auto& base, auto& slope, auto& out, double scale)
@@ -343,7 +487,6 @@ namespace hase::core
             m_queue.enqueue(
                 frameSpec,
                 alpaka::KernelBundle{hase::kernels::AddScaled{scale}, m_mesh, base, slope, out});
-            alpaka::onHost::wait(m_queue);
         }
 
         void enqueueHeun(auto& base, auto& first, auto& second, auto& out)
@@ -355,7 +498,6 @@ namespace hase::core
             m_queue.enqueue(
                 frameSpec,
                 alpaka::KernelBundle{hase::kernels::CombineHeun{m_run.timeStep}, m_mesh, base, first, second, out});
-            alpaka::onHost::wait(m_queue);
         }
 
         void enqueueRungeKutta4()
@@ -375,7 +517,6 @@ namespace hase::core
                     m_k3,
                     m_k4,
                     m_betaNext});
-            alpaka::onHost::wait(m_queue);
         }
 
         void enqueueExponentialEuler()
@@ -395,7 +536,6 @@ namespace hase::core
                     m_dndtPump,
                     m_dndtAse,
                     m_betaNext});
-            alpaka::onHost::wait(m_queue);
         }
 
         void enqueueClip(auto& beta)
@@ -405,9 +545,9 @@ namespace hase::core
                 m_devBundle.executor,
                 alpaka::Vec{m_mesh.numberOfCells});
             m_queue.enqueue(frameSpec, alpaka::KernelBundle{hase::kernels::ClipBeta{}, m_mesh, beta});
-            alpaka::onHost::wait(m_queue);
         }
 
+        ForwardPhiAseContext<T_Device, T_Executor> m_forwardAseContext;
         T_Device& m_device;
         T_Queue m_queue;
         hase::alpakaUtils::DevBundle<T_Device, T_Executor> m_devBundle;
@@ -415,7 +555,6 @@ namespace hase::core
         ComputeParameters& m_compute;
         SimulationRunControl const& m_run;
         HostMesh& m_hostMesh;
-        DeviceMeshContainer<T_Device> m_meshContainer;
         DeviceMeshView m_mesh;
 
         T_DoubleBuffer m_beta;
@@ -433,6 +572,8 @@ namespace hase::core
         T_DoubleBuffer m_pointPumpIntegral;
         T_DoubleBuffer m_lumpedPointVolume;
         Result m_lastAseResult;
+        std::size_t m_nextOutputStep = 0u;
+        bool m_phiAseDeviceResident = false;
     };
 
     inline int startTimeSteppedSimulation(
@@ -440,7 +581,8 @@ namespace hase::core
         ComputeParameters& compute,
         SimulationRunControl const& run,
         HostMesh& hostMesh,
-        std::function<void(SimulationSnapshot const&)> const& callback)
+        std::function<void(SimulationSnapshot const&)> const& callback,
+        std::function<std::vector<double>(unsigned)> const& receiveControl = {})
     {
         detail::validateRunParameters(run);
         auto backends = alpaka::onHost::allBackends(alpaka::onHost::enabledApis, alpaka::exec::enabledExecutors);
@@ -455,14 +597,33 @@ namespace hase::core
                 {
                     return 0;
                 }
-                auto device = devSelector.makeDevice(0);
-                if(!isSelected(backend, device, compute))
+                auto sampleDevice = devSelector.makeDevice(0);
+                if(hase::alpakaUtils::getNameForBackend(backend, sampleDevice) != compute.backend)
                 {
                     return 0;
                 }
+                std::size_t const deviceCount = devSelector.getDeviceCount();
+                compute.devices.resize(deviceCount);
+                std::iota(compute.devices.begin(), compute.devices.end(), 0u);
+                compute.gpu_i = compute.devices.front();
+                if(compute.numDevices == 0u)
+                    compute.numDevices = static_cast<unsigned>(deviceCount);
+                if(compute.numDevices > deviceCount)
+                {
+                    dout(V_WARNING) << "Requested number of devices (" << compute.numDevices
+                                    << ") exceeds the available device count (" << deviceCount
+                                    << "); using all available devices." << std::endl;
+                    compute.numDevices = static_cast<unsigned>(deviceCount);
+                }
+                compute.devices.resize(compute.numDevices);
+                using T_Device = ALPAKA_TYPEOF(sampleDevice);
+                std::vector<T_Device> devices;
+                devices.reserve(compute.devices.size());
+                for(unsigned deviceIndex : compute.devices)
+                    devices.emplace_back(devSelector.makeDevice(deviceIndex));
                 oneDidRun = true;
-                CompiledSimulationRunner runner{device, exec, experiment, compute, run, hostMesh};
-                runner.run(callback);
+                CompiledSimulationRunner runner{std::move(devices), exec, experiment, compute, run, hostMesh};
+                runner.run(callback, receiveControl);
                 return 0;
             },
             backends);
@@ -472,7 +633,7 @@ namespace hase::core
             std::ostringstream message;
             message << "Backend '" << compute.backend
                     << "' did not match any available backend with an available device. Available backends:";
-            for(auto const& element : backendList())
+            for(auto const& element : hase::alpakaUtils::availableBackendNames())
             {
                 message << "\n  " << element;
             }

--- a/include/kernels/forwardPhiAseMapping.hpp
+++ b/include/kernels/forwardPhiAseMapping.hpp
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 Tim Hanel
+ *
+ * This file is part of HASEonGPU
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+
+#include <alpakaUtils/DevBundle.hpp>
+#include <alpakaUtils/utils.hpp>
+#include <core/mesh.hpp>
+
+#include <limits>
+
+namespace hase::kernels
+{
+    struct BuildBetaVolumePrefix
+    {
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            core::DeviceMeshView const mesh,
+            auto betaVolume,
+            auto betaVolumePrefix,
+            auto betaVolumeTotal) const
+        {
+            for(auto [worker] :
+                alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{1u}))
+            {
+                double total = 0.0;
+                for(unsigned cell = 0u; cell < mesh.numberOfCells; ++cell)
+                {
+                    total += betaVolume[cell] * static_cast<double>(mesh.cellVolumes[cell]);
+                    betaVolumePrefix[cell] = total;
+                }
+                betaVolumeTotal[worker] = total;
+            }
+        }
+    };
+
+    struct FinalizeForwardVolumePhiAse
+    {
+        unsigned rayCount;
+        double betaVolumeTotal;
+        double fluorescenceRate;
+        double sigmaA;
+        double sigmaE;
+
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            core::DeviceMeshView const mesh,
+            auto scoreSum,
+            auto scoreSquareSum,
+            auto droppedRays,
+            auto volumePhiAse,
+            auto standardError,
+            auto relativeStandardError,
+            auto volumeDndtAse) const
+        {
+            for(auto [cell] : alpaka::onAcc::makeIdxMap(
+                    acc,
+                    alpaka::onAcc::worker::threadsInGrid,
+                    alpaka::IdxRange{mesh.numberOfCells}))
+            {
+                double const volume = static_cast<double>(mesh.cellVolumes[cell]);
+                double const maximum = std::numeric_limits<double>::max();
+                double relativeError = maximum;
+                double absoluteError = maximum;
+                double estimate = 0.0;
+                if(rayCount > 0u && volume > 0.0)
+                {
+                    estimate = scoreSum[cell] * betaVolumeTotal / (static_cast<double>(rayCount) * volume);
+                    if(droppedRays[cell] == 0u && rayCount >= 2u && alpaka::math::isfinite(scoreSum[cell])
+                       && alpaka::math::isfinite(scoreSquareSum[cell]))
+                    {
+                        if(scoreSum[cell] == 0.0)
+                        {
+                            relativeError = std::numeric_limits<double>::quiet_NaN();
+                            absoluteError = 0.0;
+                        }
+                        else
+                        {
+                            double const n = static_cast<double>(rayCount);
+                            double const relativeVariance
+                                = (n * scoreSquareSum[cell] / (scoreSum[cell] * scoreSum[cell]) - 1.0) / n;
+                            relativeError = alpaka::math::sqrt(alpaka::math::max(0.0, relativeVariance));
+                            absoluteError = relativeError * alpaka::math::abs(estimate) * fluorescenceRate;
+                        }
+                    }
+                }
+                float const phiAse = static_cast<float>(estimate * fluorescenceRate);
+                volumePhiAse[cell] = phiAse;
+                standardError[cell] = absoluteError;
+                relativeStandardError[cell] = relativeError;
+                double const gainPerDensity = mesh.betaVolume[cell] * (sigmaE + sigmaA) - sigmaA;
+                volumeDndtAse[cell] = gainPerDensity * static_cast<double>(phiAse);
+            }
+        }
+    };
+
+    void enqueueBuildBetaVolumePrefix(
+        auto& devBundle,
+        auto const& queue,
+        core::DeviceMeshView const mesh,
+        auto const& betaVolume,
+        auto& betaVolumePrefix,
+        auto& betaVolumeTotal)
+    {
+        auto frameSpec
+            = hase::alpakaUtils::getFrameSpec<uint32_t>(devBundle.device, devBundle.executor, alpaka::Vec{1u});
+        queue.enqueue(
+            frameSpec,
+            alpaka::KernelBundle{BuildBetaVolumePrefix{}, mesh, betaVolume, betaVolumePrefix, betaVolumeTotal});
+    }
+
+    void enqueueFinalizeForwardCellPhiAse(
+        auto& devBundle,
+        auto const& queue,
+        core::DeviceMeshView const mesh,
+        auto const& scoreSum,
+        auto const& scoreSquareSum,
+        auto const& droppedRays,
+        auto& volumePhiAse,
+        auto& standardError,
+        auto& relativeStandardError,
+        auto& volumeDndtAse,
+        unsigned rayCount,
+        double betaVolumeTotal,
+        double fluorescenceRate,
+        double sigmaA,
+        double sigmaE)
+    {
+        auto cellFrameSpec = hase::alpakaUtils::getFrameSpec<uint32_t>(
+            devBundle.device,
+            devBundle.executor,
+            alpaka::Vec{mesh.numberOfCells});
+        queue.enqueue(
+            cellFrameSpec,
+            alpaka::KernelBundle{
+                FinalizeForwardVolumePhiAse{rayCount, betaVolumeTotal, fluorescenceRate, sigmaA, sigmaE},
+                mesh,
+                scoreSum,
+                scoreSquareSum,
+                droppedRays,
+                volumePhiAse,
+                standardError,
+                relativeStandardError,
+                volumeDndtAse});
+    }
+
+} // namespace hase::kernels

--- a/pyInclude/__init__.py
+++ b/pyInclude/__init__.py
@@ -58,6 +58,7 @@ from .simulation import (
     Simulation,
     TimeStepState,
     TimeSteppedSimulation,
+    autonomous_final,
 )
 from .structures import Result as TransportResult
 from .gainMap import calcGainFromState

--- a/pyInclude/openpmd/transport.py
+++ b/pyInclude/openpmd/transport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import queue
 import subprocess
@@ -452,10 +453,12 @@ def _attributeValues(phiAse, gainMedium, crossSections):
     values.update(phiAse.openPmdAttributes(numberOfSamples=number_of_samples))
     return values
 
-def _arrayFields(gainMedium, crossSections, *, phiAse=None, include_static=True):
+def _arrayFields(gainMedium, crossSections, *, phiAse=None, include_static=True, dynamic_fields=None):
     context = _fieldContext(gainMedium)
     for field in _fieldsFromDomain(gainMedium.openPmdFields(context)):
         if include_static or field.spec.name in DYNAMIC_FIELD_NAMES:
+            if not include_static and dynamic_fields is not None and field.recordName not in dynamic_fields:
+                continue
             yield field
     if include_static:
         yield from _fieldsFromDomain(crossSections.openPmdFields(spectralContext))
@@ -842,7 +845,17 @@ def _open_input_series(path, *, backend=None):
     return series
 
 
-def _write_input_iteration(series, iteration_index, phiAse, gainMedium, crossSections, *, include_static=True, runControl=None):
+def _write_input_iteration(
+    series,
+    iteration_index,
+    phiAse,
+    gainMedium,
+    crossSections,
+    *,
+    include_static=True,
+    runControl=None,
+    dynamic_fields=None,
+):
     iteration = series.snapshots()[int(iteration_index)]
     iteration.time = 0.0
     iteration.dt = 1.0
@@ -864,7 +877,13 @@ def _write_input_iteration(series, iteration_index, phiAse, gainMedium, crossSec
     else:
         iteration.set_attribute("haseStaticUpdate", False)
 
-    for field in _arrayFields(gainMedium, crossSections, phiAse=phiAse, include_static=include_static):
+    for field in _arrayFields(
+        gainMedium,
+        crossSections,
+        phiAse=phiAse,
+        include_static=include_static,
+        dynamic_fields=dynamic_fields,
+    ):
         _writeArrayField(iteration, field)
 
     iteration.close()
@@ -889,7 +908,17 @@ class OpenPmdInputSeries:
         self.close()
         return False
 
-    def write(self, phiAse, gainMedium, crossSections, *, iteration_index=None, include_static=None, runControl=None):
+    def write(
+        self,
+        phiAse,
+        gainMedium,
+        crossSections,
+        *,
+        iteration_index=None,
+        include_static=None,
+        runControl=None,
+        dynamic_fields=None,
+    ):
         if self._series is None:
             raise RuntimeError("OpenPmdInputSeries must be used as a context manager before writing")
         index = self._next_iteration if iteration_index is None else int(iteration_index)
@@ -902,6 +931,7 @@ class OpenPmdInputSeries:
             crossSections,
             include_static=write_static,
             runControl=runControl,
+            dynamic_fields=dynamic_fields,
         )
         self._series.flush()
         self._next_iteration = max(self._next_iteration, index + 1)
@@ -974,12 +1004,14 @@ def read_result(path, *, expected_iteration_index=0) -> Result:
     raise RuntimeError(f"No result iteration was available in {path}")
 
 
-def _read_optional_scalar(series, iteration, name, dtype, default_size=None):
+def _read_optional_scalar(series, iteration, name, dtype):
     if name not in iteration.meshes:
-        if default_size is None:
-            return None
-        return np.zeros(default_size, dtype=dtype)
+        return None
     return _loadScalar(series, iteration, name, dtype)
+
+
+def _reshape_optional(value, shape):
+    return None if value is None else value.reshape(shape, order="F")
 
 
 def _has_attribute(obj, name):
@@ -1006,7 +1038,7 @@ def _result_status_values(iteration):
     }
 
 
-def read_simulation_output(path):
+def read_simulation_output(path, *, on_state=None):
     """Read C++ time-stepped simulation snapshots from an openPMD output series."""
     path = Path(path)
     series = _io().Series(str(path), _access("read_linear"), _series_config(path))
@@ -1014,38 +1046,45 @@ def read_simulation_output(path):
     for fallback_index, iteration in enumerate(series.read_iterations()):
         iteration_index = _iteration_index(iteration, fallback_index)
         number_of_cells = int(iteration.get_attribute("number_of_cells"))
-        beta_volume = _loadScalar(series, iteration, "core_beta_volume", np.float64)
-        phi_ase = _loadScalar(series, iteration, "core_result_phi_ase", np.float32)
-        standard_error = _loadScalar(series, iteration, "core_result_standard_error", np.float64)
-        relative_standard_error = _loadScalar(
+        cell_shape = (number_of_cells,)
+        beta_volume = _read_optional_scalar(series, iteration, "core_beta_volume", np.float64)
+        phi_ase = _read_optional_scalar(series, iteration, "core_result_phi_ase", np.float32)
+        dndt_ase = _read_optional_scalar(series, iteration, "core_result_dndt_ase", np.float64)
+        standard_error = _read_optional_scalar(series, iteration, "core_result_standard_error", np.float64)
+        relative_standard_error = _read_optional_scalar(
             series, iteration, "core_result_relative_standard_error", np.float64
         )
-        total_rays = _loadScalar(series, iteration, "core_result_total_rays", np.uint32)
-        dndt_ase = _loadScalar(series, iteration, "core_result_dndt_ase", np.float64)
-        cell_shape = (number_of_cells,)
-        states.append(SimpleNamespace(
+        total_rays = _read_optional_scalar(series, iteration, "core_result_total_rays", np.uint32)
+        ase_result = None
+        if any(value is not None for value in (phi_ase, standard_error, relative_standard_error, total_rays, dndt_ase)):
+            ase_result = Result(
+                phiAse=[] if phi_ase is None else phi_ase,
+                standardError=[] if standard_error is None else standard_error,
+                relativeStandardError=[] if relative_standard_error is None else relative_standard_error,
+                totalRays=[] if total_rays is None else total_rays,
+                dndtAse=[] if dndt_ase is None else dndt_ase,
+                **_result_status_values(iteration),
+            )
+        state = SimpleNamespace(
             iterationIndex=iteration_index,
             step=int(iteration.get_attribute("step_index")) if _has_attribute(iteration, "step_index") else iteration_index + 1,
             time=float(iteration.get_attribute("time")) if _has_attribute(iteration, "time") else float(iteration.time),
-            betaVolume=beta_volume.reshape(cell_shape, order="F"),
-            phiAse=phi_ase.reshape(cell_shape, order="F"),
-            standardError=standard_error.reshape(cell_shape, order="F"),
-            relativeStandardError=relative_standard_error.reshape(cell_shape, order="F"),
-            totalRays=total_rays.reshape(cell_shape, order="F"),
-            dndtAse=dndt_ase.reshape(cell_shape, order="F"),
-            dndtPump=_loadScalar(
-                series, iteration, "core_result_dndt_pump", np.float64
-            ).reshape(cell_shape, order="F"),
-            aseResult=Result(
-                phiAse=phi_ase,
-                standardError=standard_error,
-                relativeStandardError=relative_standard_error,
-                totalRays=total_rays,
-                dndtAse=dndt_ase,
-                **_result_status_values(iteration),
+            betaVolume=_reshape_optional(beta_volume, cell_shape),
+            phiAse=_reshape_optional(phi_ase, cell_shape),
+            standardError=_reshape_optional(standard_error, cell_shape),
+            relativeStandardError=_reshape_optional(relative_standard_error, cell_shape),
+            totalRays=_reshape_optional(total_rays, cell_shape),
+            dndtAse=_reshape_optional(dndt_ase, cell_shape),
+            dndtPump=_reshape_optional(
+                _read_optional_scalar(series, iteration, "core_result_dndt_pump", np.float64),
+                cell_shape,
             ),
+            aseResult=ase_result,
             staticUpdate=bool(iteration.get_attribute("haseStaticUpdate")) if _has_attribute(iteration, "haseStaticUpdate") else iteration_index == 0,
-        ))
+        )
+        states.append(state)
+        if on_state is not None:
+            on_state(state)
         iteration.close()
     series.close()
     if not states:
@@ -1580,11 +1619,23 @@ def _simulation_run_control(simulation, *, steps, pumpSteps):
         "enable_ase": bool(getattr(simulation, "enableASE", True)),
         "pre_pump": bool(getattr(simulation, "prePump", False)),
         "pump_steps": pump_steps_value,
+        "execution_mode": getattr(simulation, "executionMode", "autonomous"),
         "time_integrator": _time_integrator_name(solver),
         "pump_schema_version": 1,
         "pump_ray_count": int(pump.rayCount),
         "pump_rng_seed": int(pump.rngSeed),
     }
+    if hasattr(simulation, "outputFields"):
+        control["output_fields_string"] = json.dumps(
+            list(simulation.outputFields), separators=(",", ":")
+        )
+    output_steps = getattr(simulation, "outputSteps", None)
+    if output_steps is not None:
+        if output_steps and output_steps[-1] > int(steps):
+            raise ValueError("output_steps entries must not exceed the number of requested steps")
+        control["output_steps"] = np.asarray(output_steps, dtype=np.uint64)
+    control_fields = getattr(simulation, "controlFields", ())
+    control["control_fields_string"] = json.dumps(list(control_fields), separators=(",", ":"))
     control.update(_general_pump_attributes(simulation))
     if hasattr(solver, "iterations"):
         control["implicit_iterations"] = int(solver.iterations)
@@ -1729,34 +1780,109 @@ def _write_simulation_input(input_path, spec, simulation, run_control, *, close_
             iteration_index=0,
             include_static=True,
             runControl=run_control,
+            dynamic_fields={"beta_volume"},
         )
         if close_after is not None:
             close_after.wait()
 
 
-def _run_streaming_simulation(command, input_path, output_path, spec, simulation, run_control):
+def _run_streaming_simulation(
+    command,
+    input_path,
+    output_path,
+    spec,
+    simulation,
+    run_control,
+    *,
+    on_state=None,
+):
     """Run compiled simulation while Python threads exchange SST snapshots."""
     result_queue = queue.Queue(maxsize=1)
     input_queue = queue.Queue(maxsize=1)
+    control_queue = queue.Queue(maxsize=1)
+    control_ack_queue = queue.Queue(maxsize=1)
     backend_finished = threading.Event()
+    synchronized_debug = getattr(simulation, "executionMode", "autonomous") == "synchronized-debug"
 
     def read_output():
         try:
-            result_queue.put((True, read_simulation_output(output_path)))
+            def receive_state(state):
+                if on_state is not None:
+                    on_state(state)
+                if synchronized_debug and int(state.step) < int(run_control["number_of_steps"]):
+                    completed_step = int(state.step)
+                    control_queue.put(completed_step)
+                    acknowledged_step = control_ack_queue.get()
+                    if acknowledged_step != completed_step:
+                        raise RuntimeError(
+                            f"synchronized-debug control iteration {completed_step} was not published"
+                        )
+
+            if on_state is None and not synchronized_debug:
+                snapshots = read_simulation_output(output_path)
+            else:
+                snapshots = read_simulation_output(output_path, on_state=receive_state)
+            result_queue.put((True, snapshots))
         except BaseException as exc:
             result_queue.put((False, exc))
+            if proc.poll() is None:
+                proc.kill()
+        finally:
+            if synchronized_debug:
+                try:
+                    control_queue.put_nowait(None)
+                except queue.Full:
+                    pass
 
     def write_input():
         try:
-            _write_simulation_input(
-                input_path,
-                spec,
-                simulation,
-                run_control,
-                close_after=backend_finished,
-            )
+            if not synchronized_debug:
+                _write_simulation_input(
+                    input_path,
+                    spec,
+                    simulation,
+                    run_control,
+                    close_after=backend_finished,
+                )
+            else:
+                with OpenPmdInputSeries(input_path, backend=spec.name) as writer:
+                    writer.write(
+                        simulation.phiASE,
+                        simulation.gainMedium,
+                        simulation.crossSections,
+                        iteration_index=0,
+                        include_static=True,
+                        runControl=run_control,
+                        dynamic_fields={"beta_volume"},
+                    )
+                    for expected_step in range(1, int(run_control["number_of_steps"])):
+                        completed_step = control_queue.get()
+                        if completed_step is None:
+                            raise RuntimeError(
+                                "synchronized-debug output ended before the next control exchange"
+                            )
+                        if completed_step != expected_step:
+                            raise RuntimeError(
+                                f"synchronized-debug expected completed step {expected_step}, "
+                                f"received {completed_step}"
+                            )
+                        writer.write(
+                            simulation.phiASE,
+                            simulation.gainMedium,
+                            simulation.crossSections,
+                            iteration_index=completed_step,
+                            include_static=False,
+                            dynamic_fields=set(getattr(simulation, "controlFields", ())),
+                        )
+                        control_ack_queue.put(completed_step)
+                    backend_finished.wait()
             input_queue.put((True, None))
         except BaseException as exc:
+            if synchronized_debug:
+                try:
+                    control_ack_queue.put_nowait(None)
+                except queue.Full:
+                    pass
             input_queue.put((False, exc))
             if proc.poll() is None:
                 proc.kill()
@@ -1820,7 +1946,16 @@ def _run_streaming_simulation(command, input_path, output_path, spec, simulation
     return payload
 
 
-def runSimulation(simulation, *, steps, pumpSteps=None, transport=None, command_prefix=None, workspace_dir=None):
+def runSimulation(
+    simulation,
+    *,
+    steps,
+    pumpSteps=None,
+    transport=None,
+    command_prefix=None,
+    workspace_dir=None,
+    on_state=None,
+):
     """Run the full time-stepped Simulation in the compiled C++/alpaka backend."""
     steps = int(steps)
     if steps <= 0:
@@ -1829,6 +1964,8 @@ def runSimulation(simulation, *, steps, pumpSteps=None, transport=None, command_
     _ensure_backend_available(spec.name)
     executable = findCalcPhiAse()
     run_control = _simulation_run_control(simulation, steps=steps, pumpSteps=pumpSteps)
+    if simulation.executionMode == "synchronized-debug" and not spec.streaming:
+        raise ValueError("synchronized-debug requires an openPMD streaming backend")
 
     artifact_root = _artifact_root()
     if artifact_root is None and workspace_dir is not None:
@@ -1854,7 +1991,15 @@ def runSimulation(simulation, *, steps, pumpSteps=None, transport=None, command_
         ]
 
         if spec.streaming:
-            return _run_streaming_simulation(command, input_path, output_path, spec, simulation, run_control)
+            return _run_streaming_simulation(
+                command,
+                input_path,
+                output_path,
+                spec,
+                simulation,
+                run_control,
+                on_state=on_state,
+            )
 
         _write_simulation_input(input_path, spec, simulation, run_control)
         completed = subprocess.run(command, check=False, text=True, capture_output=True)
@@ -1862,7 +2007,7 @@ def runSimulation(simulation, *, steps, pumpSteps=None, transport=None, command_
         if completed.returncode != 0:
             detail = _backend_failure_detail(stdout=completed.stdout, stderr=completed.stderr)
             raise RuntimeError(f"calcPhiASE failed with return code {completed.returncode}{detail}")
-        return read_simulation_output(output_path)
+        return read_simulation_output(output_path, on_state=on_state)
 
 
 def openStream(*, transport=None, command_prefix=None, workspace_dir=None, watchdog_interval=None):

--- a/pyInclude/simulation.py
+++ b/pyInclude/simulation.py
@@ -35,6 +35,29 @@ from .timeIntegration import TimeIntegrationSolver
 
 HASE_CONFIGURE_HINT = "Run `hase-configure` to generate a matching backend/openPMD setup."
 
+SIMULATION_OUTPUT_FIELDS = (
+    "beta_volume",
+    "phi_ase",
+    "standard_error",
+    "relative_standard_error",
+    "total_rays",
+    "dndt_ase",
+    "dndt_pump",
+)
+SIMULATION_CONTROL_FIELDS = ("beta_volume",)
+
+
+def autonomous_final(number_of_steps):
+    """Return the explicit output index list for a final-state-only autonomous run."""
+    final_step = int(number_of_steps)
+    if final_step <= 0:
+        raise ValueError("number_of_steps must be positive")
+    return (final_step,)
+
+
+def _optional_state_array(values, dtype):
+    return None if values is None else np.asarray(values, dtype=dtype).copy()
+
 
 def _preferredDefaultBackend():
     try:
@@ -408,22 +431,22 @@ class TimeStepState:
     """Completed one-based step index."""
     time: float
     """Physical simulation time after the step, in seconds."""
-    betaVolume: np.ndarray
-    """Authoritative excited-state fraction for every Tet4 cell."""
+    betaVolume: np.ndarray | None
+    """Authoritative excited-state fraction for every Tet4 cell, when selected."""
     phiAse: np.ndarray | None
-    """ASE flux for every Tet4 cell, or ``None`` if unavailable."""
-    standardError: np.ndarray | None
-    """Absolute one-sigma error of the cell ASE flux estimate."""
-    relativeStandardError: np.ndarray | None
-    """Relative one-sigma error of the cell ASE flux estimate."""
-    totalRays: np.ndarray | None
-    """Ray visit count for every Tet4 cell."""
-    dndtAse: np.ndarray
-    """Cell-centered ASE depletion contribution to ``d beta / dt``."""
-    dndtPump: np.ndarray
-    """Cell-centered pump contribution to ``d beta / dt``."""
+    """ASE flux for every Tet4 cell, when selected."""
+    dndtAse: np.ndarray | None
+    """Cell-centered ASE depletion contribution to ``d beta / dt``, when selected."""
+    dndtPump: np.ndarray | None
+    """Cell-centered pump contribution to ``d beta / dt``, when selected."""
     aseResult: object | None
     """Raw lower-level ASE result object for advanced inspection."""
+    standardError: np.ndarray | None = None
+    """Absolute one-sigma error of the cell ASE estimate, when selected."""
+    relativeStandardError: np.ndarray | None = None
+    """Relative one-sigma error of the cell ASE estimate, when selected."""
+    totalRays: np.ndarray | None = None
+    """Ray visit count for each cell, when selected."""
     topology: object | None = None
     """Static mesh topology used by geometry-aware state callbacks."""
     @property
@@ -453,8 +476,9 @@ class Simulation:
     Python sends the initial setup to the compiled backend and receives
     ``TimeStepState`` snapshots after completed steps. Register ``on_init`` for
     one-time Python setup before launch and ``on_step`` for snapshot consumers.
-    ``beforeStep`` is retained only to report that per-step Python mutation is
-    unsupported by compiled runs.
+    Autonomous runs never call Python between backend steps. Synchronized-debug
+    runs additionally allow ``beforeStep`` callbacks to update explicitly
+    selected control fields between steps.
     """
 
     gainMedium: GainMedium
@@ -469,6 +493,10 @@ class Simulation:
     pumpSolver: MonteCarloPumpSolver
     maxSteps: int | None
     reportTimings: bool
+    executionMode: str
+    outputSteps: tuple[int, ...] | None
+    outputFields: tuple[str, ...]
+    controlFields: tuple[str, ...]
     _pumpRegistrations: list
     _time: float
     _step: int
@@ -492,6 +520,10 @@ class Simulation:
         enable_ase=True,
         pre_pump=False,
         report_timings=False,
+        execution_mode="autonomous",
+        output_steps=None,
+        output_fields=None,
+        control_fields=(),
     ):
         self.gainMedium = gain_medium
         self.pump = None
@@ -505,6 +537,12 @@ class Simulation:
         self.pumpSolver = MonteCarloPumpSolver() if pump_solver is None else pump_solver
         self.maxSteps = None if max_steps is None else int(max_steps)
         self.reportTimings = bool(report_timings)
+        self.executionMode = str(execution_mode)
+        self.outputSteps = None if output_steps is None else tuple(int(step) for step in output_steps)
+        self.outputFields = tuple(
+            SIMULATION_OUTPUT_FIELDS if output_fields is None else (str(field) for field in output_fields)
+        )
+        self.controlFields = tuple(str(field) for field in control_fields)
         self._pumpRegistrations = []
         self._time = 0.0
         self._step = 0
@@ -526,6 +564,30 @@ class Simulation:
             raise TypeError("pump_solver must be MonteCarloPumpSolver")
         if self.maxSteps is not None and self.maxSteps <= 0:
             raise ValueError("max_steps must be positive")
+        if self.executionMode not in {"autonomous", "synchronized-debug"}:
+            raise ValueError("execution_mode must be 'autonomous' or 'synchronized-debug'")
+        if self.outputSteps is not None and not self.outputSteps:
+            raise ValueError("output_steps must be omitted or contain at least one completed-step index")
+        if self.outputSteps is not None and any(step <= 0 for step in self.outputSteps):
+            raise ValueError("output_steps must contain positive completed-step indices")
+        if self.outputSteps is not None and tuple(sorted(set(self.outputSteps))) != self.outputSteps:
+            raise ValueError("output_steps must be strictly increasing and unique")
+        if not self.outputFields:
+            raise ValueError("output_fields must contain at least one field")
+        unknown_output_fields = sorted(set(self.outputFields) - set(SIMULATION_OUTPUT_FIELDS))
+        if unknown_output_fields:
+            raise ValueError(f"unsupported output_fields: {unknown_output_fields}")
+        if len(set(self.outputFields)) != len(self.outputFields):
+            raise ValueError("output_fields must be unique")
+        if self.executionMode == "autonomous" and self.controlFields:
+            raise ValueError("control_fields require execution_mode='synchronized-debug'")
+        if self.executionMode == "synchronized-debug" and self.outputSteps is not None:
+            raise ValueError("synchronized-debug emits every completed step; output_steps must be omitted")
+        unknown_control_fields = sorted(set(self.controlFields) - set(SIMULATION_CONTROL_FIELDS))
+        if unknown_control_fields:
+            raise ValueError(f"unsupported control_fields: {unknown_control_fields}")
+        if len(set(self.controlFields)) != len(self.controlFields):
+            raise ValueError("control_fields must be unique")
         if self.crossSections is None and (
             self.phiASE.spectralProperties is not None or self.phiASE.crossSections is not None
         ):
@@ -624,11 +686,12 @@ class Simulation:
         return self
 
     def beforeStep(self, callback, *args, **kwargs):
-        """Register an unsupported legacy pre-step callback.
+        """Register a synchronized-debug control callback.
 
-        Compiled simulations cannot call Python between C++-owned steps. The
-        registration is stored so ``runSteps`` can raise a clear error instead
-        of silently ignoring the callback.
+        The callback receives the live ``Simulation`` after a completed debug
+        snapshot and before the next step. It may update fields named in
+        ``control_fields``; currently ``beta_volume`` is supported. Autonomous
+        runs reject this callback because their C++ loop never contacts Python.
         """
         self._beforeStepCallbacks.append((callback, args, kwargs))
         return self
@@ -670,8 +733,11 @@ class Simulation:
         steps = int(steps)
         if steps <= 0:
             raise ValueError("steps must be positive")
-        if self._beforeStepCallbacks:
-            raise ValueError("compiled Simulation does not support Python beforeStep callbacks during C++-owned steps")
+        if self._beforeStepCallbacks and self.executionMode != "synchronized-debug":
+            raise ValueError(
+                "beforeStep callbacks require execution_mode='synchronized-debug'; "
+                "autonomous runs do not contact Python between steps"
+            )
         if self.pump is None:
             raise ValueError("Simulation requires at least one pump registered with add_pump")
         self._runInitCallbacks()
@@ -684,35 +750,39 @@ class Simulation:
         previous_time = self._time
         run_started = perf_counter() if self.reportTimings else None
         transport_started = perf_counter() if self.reportTimings else None
-        states = transport.runSimulation(
-            self,
-            steps=steps,
-            pumpSteps=pumpSteps,
-            transport=self.phiASE.openpmdBackend,
-            **self.phiASE._transportLaunchOptions(),
-        )
-        transport_seconds = perf_counter() - transport_started if self.reportTimings else 0.0
         state_materialization_seconds = 0.0
         callback_seconds = {}
-        for raw_state in states:
+        received_states = []
+
+        def consume_raw_state(raw_state):
+            nonlocal state_materialization_seconds
             state_started = perf_counter() if self.reportTimings else None
             state = TimeStepState(
                 step=previous_step + int(raw_state.step),
                 time=previous_time + float(raw_state.time),
-                betaVolume=np.asarray(raw_state.betaVolume, dtype=np.float64).copy(),
-                phiAse=np.asarray(raw_state.phiAse, dtype=np.float64).copy(),
-                standardError=np.asarray(raw_state.standardError, dtype=np.float64).copy(),
-                relativeStandardError=np.asarray(raw_state.relativeStandardError, dtype=np.float64).copy(),
-                totalRays=np.asarray(raw_state.totalRays, dtype=np.uint32).copy(),
-                dndtAse=np.asarray(raw_state.dndtAse, dtype=np.float64).copy(),
-                dndtPump=np.asarray(raw_state.dndtPump, dtype=np.float64).copy(),
+                betaVolume=_optional_state_array(raw_state.betaVolume, np.float64),
+                phiAse=_optional_state_array(raw_state.phiAse, np.float64),
+                standardError=_optional_state_array(getattr(raw_state, "standardError", None), np.float64),
+                relativeStandardError=_optional_state_array(
+                    getattr(raw_state, "relativeStandardError", None), np.float64
+                ),
+                totalRays=_optional_state_array(getattr(raw_state, "totalRays", None), np.uint32),
+                dndtAse=_optional_state_array(raw_state.dndtAse, np.float64),
+                dndtPump=_optional_state_array(raw_state.dndtPump, np.float64),
                 aseResult=raw_state.aseResult,
                 topology=self.gainMedium.topology,
             )
-            self.gainMedium.get("betaVolume").value = backendFlat(state.betaVolume.reshape(-1, order="F"))
+            explicit_topology = hasattr(self.gainMedium.topology, "cellPointIndices")
+            if state.betaVolume is not None:
+                self.gainMedium.get("betaVolume").value = (
+                    backendFlat(state.betaVolume.reshape(-1, order="F"))
+                    if explicit_topology
+                    else state.betaVolume
+                )
             self._lastState = state
             self._step = state.step
             self._time = state.time
+            received_states.append(state)
             if self.reportTimings:
                 state_materialization_seconds += perf_counter() - state_started
             for callback, args, kwargs in self._callbacks:
@@ -723,12 +793,30 @@ class Simulation:
                     callback_seconds[callback_name] = callback_seconds.get(callback_name, 0.0) + (
                         perf_counter() - callback_started
                     )
+            if self.executionMode == "synchronized-debug" and int(raw_state.step) < steps:
+                for callback, args, kwargs in self._beforeStepCallbacks:
+                    callback(self, *args, **kwargs)
+
+        states = transport.runSimulation(
+            self,
+            steps=steps,
+            pumpSteps=pumpSteps,
+            transport=self.phiASE.openpmdBackend,
+            on_state=consume_raw_state,
+            **self.phiASE._transportLaunchOptions(),
+        )
+        transport_seconds = perf_counter() - transport_started if self.reportTimings else 0.0
+        if not received_states:
+            for raw_state in states:
+                consume_raw_state(raw_state)
+        self._step = previous_step + steps
+        self._time = previous_time + steps * self.timeStep
         if self.reportTimings:
             total_seconds = perf_counter() - run_started
             callbacks_total = sum(callback_seconds.values())
             print(
                 "HASE frontend timing: "
-                f"steps={len(states)} total={total_seconds:.6f}s "
+                f"snapshots={len(received_states)} total={total_seconds:.6f}s "
                 f"compiled_transport_and_decode={transport_seconds:.6f}s "
                 f"snapshot_materialization={state_materialization_seconds:.6f}s "
                 f"callbacks={callbacks_total:.6f}s"

--- a/src/core/calcForwardPhiAse.cpp
+++ b/src/core/calcForwardPhiAse.cpp
@@ -116,9 +116,16 @@ namespace hase::core
 
     void finalizeForwardPhiAse(HostMesh const& hostMesh, ForwardPhiAseRawResult const& rawResult, Result& result)
     {
-        unsigned const volumeCount = static_cast<unsigned>(rawResult.scoreSum.size());
-        double const betaVolumeTotal = calcForwardBetaVolumeTotal(hostMesh);
+        finalizeForwardPhiAse(hostMesh, rawResult, calcForwardBetaVolumeTotal(hostMesh), result);
+    }
 
+    void finalizeForwardPhiAse(
+        HostMesh const& hostMesh,
+        ForwardPhiAseRawResult const& rawResult,
+        double const betaVolumeTotal,
+        Result& result)
+    {
+        unsigned const volumeCount = static_cast<unsigned>(rawResult.scoreSum.size());
         result = Result(
             std::vector(volumeCount, 0.0f),
             std::vector(volumeCount, 0.0),

--- a/src/openpmd/OpenPmdParser.cpp
+++ b/src/openpmd/OpenPmdParser.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -70,6 +71,12 @@ namespace
         constexpr char const* enableAse = "enable_ase";
         constexpr char const* prePump = "pre_pump";
         constexpr char const* pumpSteps = "pump_steps";
+        constexpr char const* executionMode = "execution_mode";
+        constexpr char const* outputSteps = "output_steps";
+        constexpr char const* outputFieldsString = "output_fields_string";
+        constexpr char const* controlFieldsString = "control_fields_string";
+        constexpr char const* legacyOutputFields = "output_fields";
+        constexpr char const* legacyControlFields = "control_fields";
         constexpr char const* timeIntegrator = "time_integrator";
         constexpr char const* implicitIterations = "implicit_iterations";
         constexpr char const* implicitTolerance = "implicit_tolerance";
@@ -182,6 +189,194 @@ namespace
         if(!obj.containsAttribute(name))
             return {};
         return unsignedVectorAttribute(obj, name);
+    }
+
+    std::vector<std::string> parseStringVectorJson(std::string const& value, std::string const& attributeName)
+    {
+        std::size_t position = 0u;
+        auto skipWhitespace = [&]()
+        {
+            while(position < value.size() && std::isspace(static_cast<unsigned char>(value[position])))
+            {
+                ++position;
+            }
+        };
+        auto invalidJson = [&]() -> void
+        { throw std::runtime_error("openPMD attribute '" + attributeName + "' must be a JSON array of strings"); };
+
+        skipWhitespace();
+        if(position == value.size() || value[position++] != '[')
+        {
+            invalidJson();
+        }
+
+        std::vector<std::string> result;
+        skipWhitespace();
+        if(position < value.size() && value[position] == ']')
+        {
+            ++position;
+            skipWhitespace();
+            if(position != value.size())
+            {
+                invalidJson();
+            }
+            return result;
+        }
+
+        while(position < value.size())
+        {
+            if(value[position++] != '"')
+            {
+                invalidJson();
+            }
+            std::string item;
+            bool closed = false;
+            while(position < value.size())
+            {
+                char const character = value[position++];
+                if(character == '"')
+                {
+                    closed = true;
+                    break;
+                }
+                if(static_cast<unsigned char>(character) < 0x20u)
+                {
+                    invalidJson();
+                }
+                if(character != '\\')
+                {
+                    item += character;
+                    continue;
+                }
+                if(position == value.size())
+                {
+                    invalidJson();
+                }
+                switch(value[position++])
+                {
+                case '"':
+                    item += '"';
+                    break;
+                case '\\':
+                    item += '\\';
+                    break;
+                case '/':
+                    item += '/';
+                    break;
+                case 'b':
+                    item += '\b';
+                    break;
+                case 'f':
+                    item += '\f';
+                    break;
+                case 'n':
+                    item += '\n';
+                    break;
+                case 'r':
+                    item += '\r';
+                    break;
+                case 't':
+                    item += '\t';
+                    break;
+                default:
+                    invalidJson();
+                }
+            }
+            if(!closed)
+            {
+                invalidJson();
+            }
+            result.push_back(std::move(item));
+
+            skipWhitespace();
+            if(position == value.size())
+            {
+                invalidJson();
+            }
+            char const separator = value[position++];
+            if(separator == ']')
+            {
+                skipWhitespace();
+                if(position != value.size())
+                {
+                    invalidJson();
+                }
+                return result;
+            }
+            if(separator != ',')
+            {
+                invalidJson();
+            }
+            skipWhitespace();
+        }
+        invalidJson();
+        return {};
+    }
+
+    std::string stringVectorJson(std::vector<std::string> const& values)
+    {
+        std::string result{"["};
+        for(auto const& value : values)
+        {
+            if(result.size() > 1u)
+            {
+                result += ',';
+            }
+            result += '"';
+            for(char const character : value)
+            {
+                switch(character)
+                {
+                case '"':
+                    result += "\\\"";
+                    break;
+                case '\\':
+                    result += "\\\\";
+                    break;
+                case '\b':
+                    result += "\\b";
+                    break;
+                case '\f':
+                    result += "\\f";
+                    break;
+                case '\n':
+                    result += "\\n";
+                    break;
+                case '\r':
+                    result += "\\r";
+                    break;
+                case '\t':
+                    result += "\\t";
+                    break;
+                default:
+                    if(static_cast<unsigned char>(character) < 0x20u)
+                    {
+                        throw std::runtime_error("simulation field names must not contain control characters");
+                    }
+                    result += character;
+                }
+            }
+            result += '"';
+        }
+        result += ']';
+        return result;
+    }
+
+    std::vector<std::string> stringVectorAttribute(
+        io::Attributable const& obj,
+        std::string const& canonicalName,
+        std::string const& legacyName,
+        std::vector<std::string> fallback)
+    {
+        if(obj.containsAttribute(canonicalName))
+        {
+            return parseStringVectorJson(attribute<std::string>(obj, canonicalName), canonicalName);
+        }
+        if(obj.containsAttribute(legacyName))
+        {
+            return attribute<std::vector<std::string>>(obj, legacyName);
+        }
+        return fallback;
     }
 
     template<typename T>
@@ -1277,6 +1472,17 @@ namespace hase::openpmd
         run.enableAse = attributeOr<bool>(iteration, field::enableAse, true);
         run.prePump = attributeOr<bool>(iteration, field::prePump, false);
         run.pumpSteps = attributeOr<unsigned>(iteration, field::pumpSteps, std::numeric_limits<unsigned>::max());
+        run.executionMode
+            = attributeOr<std::string>(iteration, field::executionMode, core::SimulationExecutionMode::AUTONOMOUS);
+        if(iteration.containsAttribute(field::outputSteps))
+            run.outputSteps = unsignedVectorAttribute(iteration, field::outputSteps);
+        run.outputFields = stringVectorAttribute(
+            iteration,
+            field::outputFieldsString,
+            field::legacyOutputFields,
+            core::SimulationOutputField::all());
+        run.controlFields
+            = stringVectorAttribute(iteration, field::controlFieldsString, field::legacyControlFields, {});
         run.timeIntegration.method
             = attributeOr<std::string>(iteration, field::timeIntegrator, core::TimeIntegrator::EXPLICIT_EULER);
         run.timeIntegration.implicitIterations = attributeOr<unsigned>(iteration, field::implicitIterations, 8u);
@@ -1709,64 +1915,74 @@ namespace hase::openpmd
                 {-4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0});
         }
 
-        writeFlatScalar<double>(
-            iteration,
-            prefix + "beta_volume",
-            snapshot.betaVolume,
-            {"cell"},
-            {mesh.numberOfCells},
-            true);
+        iteration.setAttribute(field::outputFieldsString, stringVectorJson(snapshot.fields));
+        if(snapshot.contains(core::SimulationOutputField::BETA_VOLUME))
+        {
+            writeFlatScalar<double>(
+                iteration,
+                prefix + "beta_volume",
+                snapshot.betaVolume,
+                {"cell"},
+                {mesh.numberOfCells},
+                true);
+        }
 
         std::string const resultPrefix = prefix + "result_";
-        writeScalar(
-            iteration,
-            resultPrefix + "phi_ase",
-            snapshot.aseResult.phiAse,
-            io::Extent{mesh.numberOfCells},
-            {"cell"},
-            "cm^-2 s^-1",
-            1.0e4,
-            {-2.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
-        writeScalar(
-            iteration,
-            resultPrefix + "standard_error",
-            snapshot.aseResult.standardError,
-            io::Extent{mesh.numberOfCells},
-            {"cell"},
-            "cm^-2 s^-1",
-            1.0e4,
-            {-2.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
-        writeScalar(
-            iteration,
-            resultPrefix + "relative_standard_error",
-            snapshot.aseResult.relativeStandardError,
-            io::Extent{mesh.numberOfCells},
-            {"cell"});
-        writeScalar(
-            iteration,
-            resultPrefix + "total_rays",
-            snapshot.aseResult.totalRays,
-            io::Extent{mesh.numberOfCells},
-            {"cell"},
-            "count");
-        writeScalar(
-            iteration,
-            resultPrefix + "dndt_ase",
-            snapshot.dndtAse,
-            io::Extent{mesh.numberOfCells},
-            {"cell"},
-            "s^-1",
-            1.0,
-            {0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
-        writeScalar(
-            iteration,
-            prefix + "result_dndt_pump",
-            snapshot.dndtPump,
-            io::Extent{mesh.numberOfCells},
-            {"cell"},
-            "s^-1",
-            1.0,
-            {0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
+        if(snapshot.contains(core::SimulationOutputField::PHI_ASE))
+            writeScalar(
+                iteration,
+                resultPrefix + "phi_ase",
+                snapshot.aseResult.phiAse,
+                io::Extent{mesh.numberOfCells},
+                {"cell"},
+                "cm^-2 s^-1",
+                1.0e4,
+                {-2.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
+        if(snapshot.contains(core::SimulationOutputField::STANDARD_ERROR))
+            writeScalar(
+                iteration,
+                resultPrefix + "standard_error",
+                snapshot.aseResult.standardError,
+                io::Extent{mesh.numberOfCells},
+                {"cell"},
+                "cm^-2 s^-1",
+                1.0e4,
+                {-2.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
+        if(snapshot.contains(core::SimulationOutputField::RELATIVE_STANDARD_ERROR))
+            writeScalar(
+                iteration,
+                resultPrefix + "relative_standard_error",
+                snapshot.aseResult.relativeStandardError,
+                io::Extent{mesh.numberOfCells},
+                {"cell"});
+        if(snapshot.contains(core::SimulationOutputField::TOTAL_RAYS))
+            writeScalar(
+                iteration,
+                resultPrefix + "total_rays",
+                snapshot.aseResult.totalRays,
+                io::Extent{mesh.numberOfCells},
+                {"cell"},
+                "count");
+        if(snapshot.contains(core::SimulationOutputField::DNDT_ASE))
+            writeScalar(
+                iteration,
+                resultPrefix + "dndt_ase",
+                snapshot.dndtAse,
+                io::Extent{mesh.numberOfCells},
+                {"cell"},
+                "s^-1",
+                1.0,
+                {0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
+        if(snapshot.contains(core::SimulationOutputField::DNDT_PUMP))
+            writeScalar(
+                iteration,
+                prefix + "result_dndt_pump",
+                snapshot.dndtPump,
+                io::Extent{mesh.numberOfCells},
+                {"cell"},
+                "s^-1",
+                1.0,
+                {0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0});
         iteration.close();
     }
 
@@ -1839,7 +2055,18 @@ namespace hase::openpmd
 
     void Parser::runCoreSimulation()
     {
-        auto simulation = read();
+        auto const inputStream = m_inputPath.string();
+#if defined(MPI_FOUND) && !defined(DISABLE_MPI)
+        io::Series inputSeries(inputStream, io::Access::READ_LINEAR, m_comm, seriesConfig(inputStream));
+#else
+        io::Series inputSeries(inputStream, io::Access::READ_LINEAR, seriesConfig(inputStream));
+#endif
+        auto inputIterations = inputSeries.readIterations();
+        auto inputIterator = inputIterations.begin();
+        if(inputIterator == inputIterations.end())
+            throw std::runtime_error("No iteration was available in the openPMD input stream.");
+        auto initialIteration = *inputIterator;
+        auto simulation = readIteration(inputSeries, initialIteration);
         bool const writesOutput = isHeadRank();
 
         std::unique_ptr<io::Series> series;
@@ -1862,14 +2089,13 @@ namespace hase::openpmd
             writesOutput,
             [&](core::SimulationSnapshot const& snapshot)
             {
-                bool const includeStatic = snapshot.step == 1u;
                 writeSimulationSnapshotIteration(
                     *series,
                     snapshot.step - 1u,
                     snapshot,
                     simulation.mesh,
                     simulation.experiment,
-                    includeStatic);
+                    false);
                 series->flush();
             },
             simulation.compute.parallelMode != core::ParallelMode::MPI};
@@ -1883,7 +2109,33 @@ namespace hase::openpmd
                 simulation.compute,
                 simulation.run,
                 simulation.mesh,
-                [&](core::SimulationSnapshot const& snapshot) { snapshotWriter.enqueue(snapshot); });
+                [&](core::SimulationSnapshot const& snapshot) { snapshotWriter.enqueue(snapshot); },
+                [&](unsigned completedStep)
+                {
+                    ++inputIterator;
+                    if(inputIterator == inputIterations.end())
+                        throw std::runtime_error(
+                            "synchronized-debug input ended before control iteration "
+                            + std::to_string(completedStep));
+                    auto controlIteration = *inputIterator;
+                    if(controlIteration.iterationIndex != completedStep)
+                        throw std::runtime_error(
+                            "synchronized-debug expected control iteration " + std::to_string(completedStep)
+                            + ", received " + std::to_string(controlIteration.iterationIndex));
+                    if(containsStaticMeshUpdate(controlIteration))
+                        validationError(
+                            "synchronized-debug control",
+                            "static topology updates are not supported after initialization");
+                    validateDynamicOnlyIteration(controlIteration, simulation);
+                    if(std::ranges::find(simulation.run.controlFields, core::SimulationControlField::BETA_VOLUME)
+                       != simulation.run.controlFields.end())
+                    {
+                        updateDynamicIteration(inputSeries, controlIteration, simulation);
+                        return simulation.mesh.betaVolume;
+                    }
+                    controlIteration.close();
+                    return std::vector<double>{};
+                });
         }
         catch(...)
         {
@@ -1891,6 +2143,7 @@ namespace hase::openpmd
         }
 
         snapshotWriter.finish();
+        inputSeries.close();
         if(series)
         {
             series->close();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ requiredHaseApi = (
     "SuperGaussianPumpProfile",
     "SurfacePumpInjector",
     "VolumeTopology",
+    "autonomous_final",
 )
 
 

--- a/tests/openpmdParserValidation.cpp
+++ b/tests/openpmdParserValidation.cpp
@@ -671,6 +671,9 @@ TEST_CASE("openPMD parser reads compiled simulation run-control attributes", "[o
             iteration.setAttribute("number_of_steps", 100u);
             iteration.setAttribute("enable_ase", false);
             iteration.setAttribute("pump_steps", 50u);
+            iteration.setAttribute("execution_mode", std::string{"synchronized-debug"});
+            iteration.setAttribute("output_fields_string", std::string{"[\"beta_volume\",\"dndt_pump\"]"});
+            iteration.setAttribute("control_fields_string", std::string{"[\"beta_volume\"]"});
             iteration.setAttribute("time_integrator", std::string{"frozen-phi-ase-runge-kutta-4"});
             using U64 = unsigned long long;
             iteration.setAttribute("pump_schema_version", 1u);
@@ -715,12 +718,32 @@ TEST_CASE("openPMD parser reads compiled simulation run-control attributes", "[o
     REQUIRE(context.run.numberOfSteps == 100u);
     REQUIRE(context.run.enableAse == false);
     REQUIRE(context.run.pumpSteps == 50u);
+    REQUIRE(context.run.outputFields == std::vector<std::string>{"beta_volume", "dndt_pump"});
+    REQUIRE(context.run.controlFields == std::vector<std::string>{"beta_volume"});
     REQUIRE(context.run.timeIntegration.method == "frozen-phi-ase-runge-kutta-4");
     REQUIRE(context.run.pump.rayCount == 1234u);
     REQUIRE(context.run.pump.rngSeed == 99u);
     REQUIRE(context.run.pump.sources.size() == 1u);
     REQUIRE(context.run.pump.sources.front().totalPower == 12.5);
     REQUIRE(context.run.pump.sources.front().relays.front().transmission == 0.75);
+}
+
+TEST_CASE("openPMD parser reads legacy string-vector run-control attributes", "[openpmd][parser]")
+{
+    auto const path = writeParserInput(
+        "legacy_string_vector_run_control",
+        [](io::Series& series, io::Iteration& iteration)
+        {
+            (void) series;
+            iteration.setAttribute(
+                "output_fields",
+                std::vector<std::string>{"beta_volume", "relative_standard_error"});
+        });
+    hase::openpmd::Parser parser{path, testPath("legacy-string-vector-run-control-output")};
+    auto context = parser.read();
+
+    REQUIRE(context.run.outputFields == std::vector<std::string>{"beta_volume", "relative_standard_error"});
+    REQUIRE(context.run.controlFields.empty());
 }
 
 TEST_CASE("openPMD parser rejects legacy compiled pump run control", "[openpmd][parser]")

--- a/tests/python/openpmd/test_transport.py
+++ b/tests/python/openpmd/test_transport.py
@@ -1264,6 +1264,31 @@ def test_inputSeriesOmitsStaticTopology(tmp_path):
     series.close()
 
 
+def test_timeSteppedInputIncludesInitialVolumeBeta(tmp_path):
+    _require_openpmd_transport_io()
+    output = tmp_path / ("time_stepped_input" + _file_suffix_for_tests())
+    simulation = SimpleNamespace(
+        phiASE=asymmetric_phi_ase(),
+        gainMedium=asymmetric_medium(),
+        crossSections=asymmetric_cross_sections(),
+    )
+
+    transport._write_simulation_input(
+        output,
+        SimpleNamespace(name=_file_backend_for_tests()),
+        simulation,
+        {"number_of_steps": 1},
+    )
+
+    series = _io().Series(str(output), _io().Access.read_only)
+    iteration = series.iterations[0]
+    np.testing.assert_array_equal(
+        _read_scalar(series, iteration, "core_beta_volume"),
+        VOLUME_BETA,
+    )
+    series.close()
+
+
 def test_cppParserRoundTripsPythonWriter(contract_input, tmp_path):
     output = tmp_path / ("round_trip_result" + _file_suffix_for_tests())
     env = os.environ.copy()
@@ -1686,6 +1711,9 @@ def test_simulation_run_control_serializes_general_pump_graph():
         gainMedium=SimpleNamespace(topology=SimpleNamespace(surfaceDomainMap=lambda: None)),
         timeStep=2.0e-6,
         timeIntegrationSolver=SimpleNamespace(name="implicit-euler", iterations=5, tolerance=1.0e-7),
+        outputFields=("beta_volume", "dndt_pump"),
+        controlFields=("beta_volume",),
+        executionMode="synchronized-debug",
     )
 
     control = transport._simulation_run_control(simulation, steps=7, pumpSteps=None)
@@ -1697,6 +1725,10 @@ def test_simulation_run_control_serializes_general_pump_graph():
     assert control["pump_schema_version"] == 1
     assert control["pump_ray_count"] == 1234
     assert control["pump_rng_seed"] == 99
+    assert control["output_fields_string"] == '["beta_volume","dndt_pump"]'
+    assert control["control_fields_string"] == '["beta_volume"]'
+    assert "output_fields" not in control
+    assert "control_fields" not in control
     assert control["pump_source_total_power"] == [12.5]
     assert control["pump_source_surfaces"].tolist() == [11]
     assert control["pump_spectrum_wavelengths"] == [940e-9]
@@ -1845,6 +1877,102 @@ def test_streaming_simulation_keeps_input_series_open_until_backend_exits(monkey
     assert states[0].step == 1
     assert closed_before_backend_exit == [False]
     assert input_closed.is_set()
+
+
+def test_streaming_synchronized_debug_exchanges_control_after_each_snapshot(monkeypatch, tmp_path):
+    initial_written = threading.Event()
+    controls_written = threading.Event()
+    writes = []
+
+    class FakeInputSeries:
+        def __init__(self, path, *, backend=None):
+            assert Path(path).name == "input.sst"
+            assert backend == "adios-sst"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            pass
+
+        def write(
+            self,
+            phi_ase,
+            gain_medium,
+            cross_sections,
+            *,
+            iteration_index,
+            include_static,
+            runControl=None,
+            dynamic_fields=None,
+        ):
+            writes.append(
+                (
+                    iteration_index,
+                    include_static,
+                    dynamic_fields,
+                    float(gain_medium.beta),
+                )
+            )
+            if iteration_index == 0:
+                initial_written.set()
+            if iteration_index == 2:
+                controls_written.set()
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, command, **kwargs):
+            pass
+
+        def poll(self):
+            return None
+
+        def kill(self):
+            raise AssertionError("the successful backend must not be killed")
+
+        def communicate(self):
+            assert controls_written.wait(timeout=2.0)
+            return "", ""
+
+    def fake_read_simulation_output(path, *, on_state=None):
+        assert initial_written.wait(timeout=2.0)
+        for step in (1, 2, 3):
+            state = SimpleNamespace(step=step)
+            if on_state is not None:
+                on_state(state)
+        return [SimpleNamespace(step=3)]
+
+    def update_control(state):
+        simulation.gainMedium.beta = float(state.step)
+
+    monkeypatch.setattr(transport, "OpenPmdInputSeries", FakeInputSeries)
+    monkeypatch.setattr(transport.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(transport, "read_simulation_output", fake_read_simulation_output)
+
+    simulation = SimpleNamespace(
+        executionMode="synchronized-debug",
+        controlFields=("beta_volume",),
+        phiASE=object(),
+        gainMedium=SimpleNamespace(beta=0.0),
+        crossSections=object(),
+    )
+    states = transport._run_streaming_simulation(
+        ["calcPhiASE", "--cpp-control"],
+        tmp_path / "input.sst",
+        tmp_path / "output.sst",
+        SimpleNamespace(name="adios-sst"),
+        simulation,
+        {"number_of_steps": 3},
+        on_state=update_control,
+    )
+
+    assert states[-1].step == 3
+    assert writes == [
+        (0, True, {"beta_volume"}, 0.0),
+        (1, False, {"beta_volume"}, 1.0),
+        (2, False, {"beta_volume"}, 2.0),
+    ]
 
 
 def test_streaming_simulation_reports_backend_exit_when_input_sender_is_blocked(monkeypatch, tmp_path):

--- a/tests/python/phiAse/test_simulationWrapper.py
+++ b/tests/python/phiAse/test_simulationWrapper.py
@@ -374,7 +374,7 @@ def testSimulationRunStepsPassesStreamingBackendToCompiledTransport(monkeypatch)
     simulation._time = 0.0
     simulation.reportTimings = False
 
-    def fake_run_simulation(simulation_arg, *, steps, pumpSteps=None, transport=None):
+    def fake_run_simulation(simulation_arg, *, steps, pumpSteps=None, transport=None, on_state=None):
         captured["simulation"] = simulation_arg
         captured["steps"] = steps
         captured["pumpSteps"] = pumpSteps

--- a/tests/python/simulation/test_laserPumpCladding.py
+++ b/tests/python/simulation/test_laserPumpCladding.py
@@ -324,6 +324,7 @@ def laserPumpCladdingBackendResults(
             maxRays=metadata["parameters"]["maxRaysPerSample"],
             relativeStandardErrorThreshold=0.05,
             adaptiveSteps=metadata["parameters"]["adaptiveSteps"],
+            outputSteps=metadata["observable"]["stepNumbers"],
         )
 
         relative_standard_error = np.asarray(state.relativeStandardError, dtype=np.float64)
@@ -412,6 +413,7 @@ def fakeCompiledSnapshots(monkeypatch):
         transport=None,
         command_prefix=None,
         workspace_dir=None,
+        on_state=None,
     ):
         calls.append(
             {
@@ -426,7 +428,8 @@ def fakeCompiledSnapshots(monkeypatch):
         )
         volume_shape = simulation.gainMedium.get("betaVolume").expectedShape
         states = []
-        for step in range(1, steps + 1):
+        emitted_steps = range(1, steps + 1) if simulation.outputSteps is None else simulation.outputSteps
+        for step in emitted_steps:
             pump_active = pumpSteps is None or step <= pumpSteps
             states.append(
                 SimpleNamespace(
@@ -446,6 +449,9 @@ def fakeCompiledSnapshots(monkeypatch):
                     aseResult=object(),
                 )
             )
+        if on_state is not None:
+            for state in states:
+                on_state(state)
         return states
 
     monkeypatch.setattr(transport, "runSimulation", fake_run_simulation)

--- a/tests/python/simulation/test_laserPumpCladdingNoReflection.py
+++ b/tests/python/simulation/test_laserPumpCladdingNoReflection.py
@@ -140,6 +140,7 @@ def testCurrentTet4WithoutReflectionsMatchesLegacyWedgeIntegral(
         maxRays=metadata["parameters"]["maxRaysPerSample"],
         relativeStandardErrorThreshold=0.05,
         adaptiveSteps=metadata["parameters"]["adaptiveSteps"],
+        outputSteps=metadata["observable"]["stepNumbers"],
     )
 
     assert state.aseResult.srmStatus == "disabled"

--- a/tests/python/simulation/test_laserPumpCladdingSsgRegression.py
+++ b/tests/python/simulation/test_laserPumpCladdingSsgRegression.py
@@ -66,6 +66,8 @@ def test_julia1DMatchesDisabledAse(tmp_path, openPmdRuntimeBackend, openPmdRunti
             "--disable-ase",
             "--timeSteps",
             "100",
+            "--output-steps",
+            *[str(step) for step in range(1, 101)],
             "--pumpSteps",
             "50",
             "--pump-ray-count",

--- a/tests/python/simulation/test_timeSteppedSimulation.py
+++ b/tests/python/simulation/test_timeSteppedSimulation.py
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
 from dataclasses import replace
 from types import SimpleNamespace
 
@@ -26,6 +27,8 @@ from HASEonGPU import (
     RungeKutta4,
     SurfacePumpInjector,
     Simulation,
+    VolumeTopology,
+    autonomous_final,
 )
 from pyInclude.openpmd import transport
 
@@ -37,16 +40,18 @@ def fakeCppSimulation(monkeypatch, smallTopology):
     def make_state(step, simulation, pump_steps):
         volume_shape = (smallTopology.numberOfTriangles, smallTopology.levels - 1)
         pump_active = pump_steps is None or step <= pump_steps
+        fields = set(simulation.outputFields)
         return SimpleNamespace(
             step=step,
             time=step * simulation.timeStep,
-            betaVolume=np.full(volume_shape, 0.125 * step),
-            phiAse=np.full(volume_shape, float(step)),
-            standardError=np.zeros(volume_shape),
-            relativeStandardError=np.zeros(volume_shape),
-            totalRays=np.zeros(volume_shape, dtype=np.uint32),
-            dndtAse=np.zeros(volume_shape),
-            dndtPump=np.ones(volume_shape) if pump_active else np.zeros(volume_shape),
+            betaVolume=np.full(volume_shape, 0.125 * step) if "beta_volume" in fields else None,
+            phiAse=np.full(volume_shape, float(step)) if "phi_ase" in fields else None,
+            standardError=np.zeros(volume_shape) if "standard_error" in fields else None,
+            relativeStandardError=np.zeros(volume_shape) if "relative_standard_error" in fields else None,
+            totalRays=np.zeros(volume_shape, dtype=np.uint32) if "total_rays" in fields else None,
+            dndtAse=np.zeros(volume_shape) if "dndt_ase" in fields else None,
+            dndtPump=(np.ones(volume_shape) if pump_active else np.zeros(volume_shape))
+            if "dndt_pump" in fields else None,
             aseResult=object(),
         )
 
@@ -58,6 +63,7 @@ def fakeCppSimulation(monkeypatch, smallTopology):
         transport=None,
         command_prefix=None,
         workspace_dir=None,
+        on_state=None,
     ):
         call = {
             "simulation": simulation,
@@ -70,7 +76,16 @@ def fakeCppSimulation(monkeypatch, smallTopology):
         if workspace_dir is not None:
             call["workspace_dir"] = workspace_dir
         captured.append(call)
-        return [make_state(step, simulation, pumpSteps) for step in range(1, steps + 1)]
+        emitted_steps = (
+            range(1, steps + 1)
+            if simulation.executionMode == "synchronized-debug" or simulation.outputSteps is None
+            else simulation.outputSteps
+        )
+        states = [make_state(step, simulation, pumpSteps) for step in emitted_steps]
+        if on_state is not None:
+            for state in states:
+                on_state(state)
+        return states
 
     monkeypatch.setattr(transport, "runSimulation", fake_run_simulation)
     return captured
@@ -149,6 +164,74 @@ def testCompiledSimulationUsesPhiAseMpiLaunchOptions(
         "3",
     ]
     assert fakeCppSimulation[-1]["workspace_dir"] == tmp_path / "IO" / "phiase_mpi"
+
+
+@pytest.mark.integration
+def testCompiledSimulationMpiRanksShareOneDeviceAndAdvanceAse(
+    pumpProperties,
+    crossSections,
+    openPmdRuntimeBackend,
+    alpakaRuntimeBackend,
+    monkeypatch,
+    tmp_path,
+):
+    rank_count_text = os.environ.get("HASE_MPI_TEST_RANKS", "").strip()
+    if not rank_count_text:
+        pytest.skip("HASE_MPI_TEST_RANKS is not configured for this test run")
+    rank_count = int(rank_count_text)
+
+    topology = VolumeTopology.fromTetrahedra(
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        ),
+        np.array([[0, 1, 2, 3]], dtype=np.uint32),
+    ).withDomains(surfaceDomains={"where": "all_exterior", "domain": 1})
+    gain_medium = GainMedium(topology).withPhysicalProperties(
+        betaVolume=np.array([0.1]),
+        claddingCellTypes=np.array([0], dtype=np.uint32),
+        refractiveIndices=[1.8, 1.0, 1.8, 1.0],
+        reflectivities=np.zeros((1, 2)),
+        nTot=2.76e20,
+        crystalTFluo=9.5e-4,
+        claddingNumber=1,
+        claddingAbsorption=0.0,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HASE_MPIEXEC_EXTRA_ARGS", "--oversubscribe")
+    phi_ase = PhiASE(
+        spectralProperties=crossSections,
+        backend=alpakaRuntimeBackend,
+        openpmdBackend=openPmdRuntimeBackend,
+        parallelMode="mpi",
+        nPerNode=rank_count,
+        numDevices=1,
+        minRays=256,
+        maxRays=256,
+        adaptiveSteps=1,
+        rngSeed=1234,
+        useReflections=False,
+    )
+    simulation = configuredSimulation(
+        pumpProperties,
+        gain_medium=gain_medium,
+        phi_ase=phi_ase,
+        time_integrator="explicit-euler",
+        time_step_size=1e-5,
+        pre_pump=True,
+    )
+
+    simulation.runSteps(2, pumpSteps=1)
+
+    state = simulation.getLastState()
+    assert state.step == 2
+    assert np.any(np.asarray(state.phiAse) > 0.0)
+    assert np.all(np.isfinite(state.betaVolume))
 
 
 def testTimeSteppedSimulationRunsCallbacksFromCppSnapshots(
@@ -298,6 +381,90 @@ def testCompiledSimulationRejectsPythonBeforeStepCallbacks(
 
     with pytest.raises(ValueError, match="beforeStep"):
         simulation.runSteps(1)
+
+
+def testAutonomousFinalIsAnOutputScheduleHelper():
+    assert autonomous_final(5) == (5,)
+    with pytest.raises(ValueError, match="positive"):
+        autonomous_final(0)
+
+
+def testAutonomousOutputScheduleAndFieldsAreAppliedAtInitialization(
+    fakeCppSimulation,
+    smallGainMedium,
+    pumpProperties,
+    crossSections,
+):
+    seen = []
+    simulation = configuredSimulation(
+        pumpProperties,
+        gain_medium=smallGainMedium,
+        phi_ase=realPhiAse(crossSections),
+        time_integrator=ExponentialEuler(),
+        time_step_size=1e-5,
+        output_steps=(2, 5),
+        output_fields=("beta_volume", "dndt_pump"),
+    ).on_step(seen.append)
+
+    simulation.runSteps(5)
+
+    assert [state.step for state in seen] == [2, 5]
+    assert seen[-1].betaVolume is not None
+    assert seen[-1].dndtPump is not None
+    assert seen[-1].phiAse is None
+    assert simulation.current_step == 5
+
+
+def testSynchronizedDebugExchangesSelectedControlAfterEveryNonfinalStep(
+    fakeCppSimulation,
+    smallGainMedium,
+    pumpProperties,
+    crossSections,
+):
+    controlled_after = []
+
+    def control(simulation):
+        controlled_after.append(simulation.current_step)
+        simulation.gainMedium.get("betaVolume").value[...] = 0.75
+
+    simulation = configuredSimulation(
+        pumpProperties,
+        gain_medium=smallGainMedium,
+        phi_ase=realPhiAse(crossSections),
+        time_integrator=ExponentialEuler(),
+        time_step_size=1e-5,
+        execution_mode="synchronized-debug",
+        control_fields=("beta_volume",),
+    ).beforeStep(control)
+
+    simulation.runSteps(3)
+
+    assert controlled_after == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"execution_mode": "autonomous", "control_fields": ("beta_volume",)}, "control_fields"),
+        ({"execution_mode": "synchronized-debug", "output_steps": (1,)}, "output_steps"),
+        ({"output_fields": ("point_beta",)}, "unsupported output_fields"),
+        ({"execution_mode": "synchronized-debug", "control_fields": ("point_beta",)}, "unsupported control_fields"),
+    ],
+)
+def testSimulationRunContractRejectsUnsupportedModeCombinations(
+    smallGainMedium,
+    crossSections,
+    kwargs,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        Simulation(
+            gain_medium=smallGainMedium,
+            phi_ase=realPhiAse(crossSections),
+            time_integrator=ExponentialEuler(),
+            time_step_size=1e-5,
+            **kwargs,
+        )
 
 
 def testCompiledSimulationRejectsExternalOpenPmdSessionOwnership(

--- a/tests/simulationSnapshotWriter.cpp
+++ b/tests/simulationSnapshotWriter.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <core/simulationRunControl.hpp>
 #include <openpmd/SimulationSnapshotWriter.hpp>
 
 #include <chrono>
@@ -11,7 +12,6 @@ namespace
 {
     template<typename T>
     concept ContainsMeshMember = requires(T value) { value.mesh; };
-
     template<typename T>
     concept ContainsPointBetaMember = requires(T value) { value.betaCells; };
 } // namespace
@@ -22,6 +22,24 @@ TEST_CASE("simulation snapshots contain dynamic state instead of a host mesh", "
     STATIC_REQUIRE_FALSE(ContainsPointBetaMember<hase::core::SimulationSnapshot>);
     STATIC_REQUIRE(std::is_same_v<decltype(hase::core::SimulationSnapshot::betaVolume), std::vector<double>>);
     STATIC_REQUIRE(std::is_same_v<decltype(hase::core::SimulationSnapshot::aseResult), hase::core::Result>);
+}
+
+TEST_CASE("simulation run fields expose only cell-centered state", "[simulation]")
+{
+    using hase::core::SimulationControlField;
+    using hase::core::SimulationOutputField;
+
+    CHECK(
+        SimulationOutputField::all()
+        == std::vector<std::string>{
+            "beta_volume",
+            "phi_ase",
+            "standard_error",
+            "relative_standard_error",
+            "total_rays",
+            "dndt_ase",
+            "dndt_pump"});
+    CHECK(SimulationControlField::all() == std::vector<std::string>{"beta_volume"});
 }
 
 TEST_CASE("simulation snapshot writer runs synchronously when requested", "[openpmd][mpi]")


### PR DESCRIPTION
## Summary

  This PR improves the compiled time-stepped simulation by:

  - Keeping simulation state and reusable buffers on the device between steps.
  - Reducing host transfers and unnecessary waits.
  - Using non-blocking queues for forward-ASE work.
  - Supporting selectable `output_steps` and `output_fields` within the Simulation()
        - allowing explicitly demanding specific time slices to be transfered back to the python front-end
  - Bounding asynchronous snapshot queues to prevent unlimited memory growth.
  - Adding `autonomous` and `synchronized-debug` execution modes.

  ## Execution modes

  ### Autonomous

  `execution_mode="autonomous"` is the default and fastest mode.

  C++ runs all time steps independently. Python only receives the requested snapshots and cannot modify the simulation between steps.

  ### Synchronized debug

  `execution_mode="synchronized-debug"` is intended for debugging.

  The backend sends a snapshot after every step and waits for Python before continuing. Python can inspect the state and update selected control fields using `beforeStep` callbacks.

  Currently, only `beta_volume` can be updated. This mode requires a streaming backend such as ADIOS/SST and should not be used for performance measurements.