### PR TITLE
Pump entry distribution stratification

### DIFF
--- a/docs/source/theoryAndModel.rst
+++ b/docs/source/theoryAndModel.rst
@@ -256,6 +256,12 @@ exterior Tet4 faces. Each source defines an aperture-integrated total power, a
 normalized spatial profile, a discrete wavelength spectrum, and an angular
 distribution.
 
+Pump entry positions use randomized systematic stratification over spatial
+subregions of the injector aperture. The subregion CDF is weighted by the
+integrated pump profile, rather than only by boundary-face area, and sampling
+within a selected subregion retains the configured continuous profile. Global
+ray indices preserve the same coverage when a ray batch is partitioned.
+
 Within a cell, pump power follows
 
 .. math::

--- a/include/kernels/generalPump.hpp
+++ b/include/kernels/generalPump.hpp
@@ -20,12 +20,14 @@
 #include <kernels/forward/rayTransition.hpp>
 #include <kernels/forward/rayWalk.hpp>
 #include <kernels/vertexAccumulation.hpp>
+#include <random/random.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <concepts>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <random>
 #include <stdexcept>
@@ -149,6 +151,97 @@ namespace hase::kernels
         return std::exp(-std::pow(std::sqrt(u * u + v * v), profile.exponent));
     }
 
+    [[nodiscard]] inline double pumpEntryWeight(
+        PumpBoundaryFace const& face,
+        hase::core::PumpProfileParameters const& profile)
+    {
+        // Seven-point Dunavant quadrature.  The CDF must represent the
+        // aperture's spatial entry distribution, not just its triangle areas:
+        // after a region is selected, rejection sampling supplies the matching
+        // conditional distribution inside that region.
+        constexpr std::array<std::array<double, 3u>, 7u> barycentric{{
+            {1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0},
+            {0.059715871789770, 0.470142064105115, 0.470142064105115},
+            {0.470142064105115, 0.059715871789770, 0.470142064105115},
+            {0.470142064105115, 0.470142064105115, 0.059715871789770},
+            {0.797426985353087, 0.101286507323456, 0.101286507323456},
+            {0.101286507323456, 0.797426985353087, 0.101286507323456},
+            {0.101286507323456, 0.101286507323456, 0.797426985353087},
+        }};
+        constexpr std::array<double, 7u> weights{
+            0.225,
+            0.132394152788506,
+            0.132394152788506,
+            0.132394152788506,
+            0.125939180544827,
+            0.125939180544827,
+            0.125939180544827};
+
+        double integral = 0.0;
+        for(std::size_t sample = 0u; sample < barycentric.size(); ++sample)
+        {
+            auto const& coordinate = barycentric[sample];
+            hase::core::Point const point = face.vertices[0] * coordinate[0] + face.vertices[1] * coordinate[1]
+                                            + face.vertices[2] * coordinate[2];
+            integral += weights[sample] * pumpProfileWeight(profile, point);
+        }
+        return face.area * integral;
+    }
+
+    inline void appendPumpEntryRegions(
+        PumpBoundaryFace const& face,
+        unsigned const remainingSubdivisions,
+        std::vector<PumpBoundaryFace>& regions)
+    {
+        if(remainingSubdivisions == 0u)
+        {
+            regions.push_back(face);
+            return;
+        }
+
+        auto const midpoint = [](hase::core::Point const a, hase::core::Point const b) { return (a + b) * 0.5; };
+        hase::core::Point const midpoint01 = midpoint(face.vertices[0], face.vertices[1]);
+        hase::core::Point const midpoint12 = midpoint(face.vertices[1], face.vertices[2]);
+        hase::core::Point const midpoint20 = midpoint(face.vertices[2], face.vertices[0]);
+        std::array<std::array<hase::core::Point, 3u>, 4u> const vertices{{
+            {face.vertices[0], midpoint01, midpoint20},
+            {midpoint01, face.vertices[1], midpoint12},
+            {midpoint20, midpoint12, face.vertices[2]},
+            {midpoint01, midpoint12, midpoint20},
+        }};
+        for(auto const& regionVertices : vertices)
+        {
+            PumpBoundaryFace region = face;
+            region.vertices = regionVertices;
+            region.centroid = (regionVertices[0] + regionVertices[1] + regionVertices[2]) * (1.0 / 3.0);
+            region.area = face.area * 0.25;
+            appendPumpEntryRegions(region, remainingSubdivisions - 1u, regions);
+        }
+    }
+
+    [[nodiscard]] inline std::vector<PumpBoundaryFace> pumpEntryRegions(std::vector<PumpBoundaryFace> const& faces)
+    {
+        // Spatial regions make the systematic CDF cover the continuous entry
+        // aperture.  A face-only CDF leaves all within-face variation random,
+        // which is especially noisy for a nonuniform beam profile.
+        constexpr unsigned subdivisionDepth = 2u;
+        constexpr std::size_t regionsPerFace = 1u << (2u * subdivisionDepth);
+        std::vector<PumpBoundaryFace> regions;
+        regions.reserve(faces.size() * regionsPerFace);
+        for(auto const& face : faces)
+            appendPumpEntryRegions(face, subdivisionDepth, regions);
+        return regions;
+    }
+
+    [[nodiscard]] inline std::size_t pumpEntryRegionForTarget(std::vector<double> const& entryCdf, double const target)
+    {
+        if(entryCdf.empty())
+            return 0u;
+        auto const region = std::upper_bound(entryCdf.cbegin(), entryCdf.cend(), target);
+        return region == entryCdf.cend() ? entryCdf.size() - 1u
+                                         : static_cast<std::size_t>(std::distance(entryCdf.cbegin(), region));
+    }
+
     template<typename T_Rng>
     [[nodiscard]] inline hase::core::Point sampleTriangle(PumpBoundaryFace const& face, T_Rng& rng)
     {
@@ -177,11 +270,19 @@ namespace hase::kernels
         auto const faces = pumpBoundaryFaces(mesh, source.surfaces);
         if(faces.empty())
             throw std::runtime_error("pump source selected no exterior boundary faces");
-        std::vector<double> areas;
-        areas.reserve(faces.size());
-        for(auto const& face : faces)
-            areas.push_back(face.area);
-        std::discrete_distribution<std::size_t> faceDistribution(areas.begin(), areas.end());
+        if(selectedRayCount == 0u)
+            return {};
+        auto const entryRegions = pumpEntryRegions(faces);
+        std::vector<double> entryCdf;
+        entryCdf.reserve(entryRegions.size());
+        double totalEntryWeight = 0.0;
+        for(auto const& region : entryRegions)
+        {
+            totalEntryWeight += pumpEntryWeight(region, source.profile);
+            entryCdf.push_back(totalEntryWeight);
+        }
+        if(!(totalEntryWeight > 0.0) || !std::isfinite(totalEntryWeight))
+            throw std::runtime_error("pump spatial profile has no finite weight on the selected exterior faces");
         std::discrete_distribution<std::size_t> spectrumDistribution(
             source.spectralWeights.begin(),
             source.spectralWeights.end());
@@ -190,17 +291,19 @@ namespace hase::kernels
             source.angularWeights.end());
         std::mt19937_64 rng(seed);
         std::uniform_real_distribution<double> uniform(0.0, 1.0);
+        double const entryStratificationOffset = hase::random::stratifiedUnitOffset(seed);
 
         std::vector<GeneralPumpRayState> rays;
         rays.reserve(selectedRayCount);
         for(unsigned ray = 0u; ray < selectedRayEnd; ++ray)
         {
-            PumpBoundaryFace const* face = nullptr;
+            double const entryTarget = (static_cast<double>(ray) + entryStratificationOffset)
+                                       / static_cast<double>(globalRayCount) * totalEntryWeight;
+            PumpBoundaryFace const* face = &entryRegions[pumpEntryRegionForTarget(entryCdf, entryTarget)];
             hase::core::Point origin;
             bool accepted = false;
             for(unsigned attempt = 0u; attempt < 100000u; ++attempt)
             {
-                face = &faces[faceDistribution(rng)];
                 origin = sampleTriangle(*face, rng);
                 if(uniform(rng) <= pumpProfileWeight(source.profile, origin))
                 {

--- a/tests/generalPump.cpp
+++ b/tests/generalPump.cpp
@@ -14,6 +14,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 #include <type_traits>
 #include <vector>
@@ -222,6 +223,7 @@ TEST_CASE("general pump samples tagged faces deterministically with conserved so
     REQUIRE(first.size() == 80u);
     REQUIRE(repeated.size() == first.size());
     double sampledPower = 0.0;
+    std::array<unsigned, 4u> entryQuarterVisits{};
     for(std::size_t ray = 0u; ray < first.size(); ++ray)
     {
         auto const& sampled = first[ray];
@@ -239,6 +241,14 @@ TEST_CASE("general pump samples tagged faces deterministically with conserved so
         CHECK(sampled.direction.z == Catch::Approx(1.0));
         CHECK(sampled.cell == 0u);
         CHECK(sampled.forbiddenFace == 3);
+        if(sampled.position.x + sampled.position.y <= 0.5)
+            ++entryQuarterVisits[0];
+        else if(sampled.position.x >= 0.5)
+            ++entryQuarterVisits[1];
+        else if(sampled.position.y >= 0.5)
+            ++entryQuarterVisits[2];
+        else
+            ++entryQuarterVisits[3];
         if(sampled.wavelength == source.wavelengths[0])
         {
             CHECK(sampled.sigmaAbsorption == source.sigmaAbsorption[0]);
@@ -252,6 +262,93 @@ TEST_CASE("general pump samples tagged faces deterministically with conserved so
         }
     }
     CHECK(sampledPower == Catch::Approx(source.totalPower));
+    for(auto const visits : entryQuarterVisits)
+        CHECK(visits == 20u);
+}
+
+TEST_CASE("general pump stratifies faces by the spatial entry distribution", "[pump][source]")
+{
+    auto const mesh = makeSingleTetMesh();
+    auto source = uniformSource(10u);
+    source.surfaces = {7, 8, 9, 10};
+    source.profile.kind = 1u;
+    source.profile.radiusU = 0.35;
+    source.profile.radiusV = 0.55;
+    source.profile.exponent = 2.0;
+    source.profile.center[0] = 0.15;
+    source.profile.center[1] = 0.1;
+
+    auto const faces = hase::kernels::pumpBoundaryFaces(mesh, source.surfaces);
+    REQUIRE(faces.size() == 4u);
+    std::array<double, 4u> entryWeights{};
+    double totalEntryWeight = 0.0;
+    auto const regions = hase::kernels::pumpEntryRegions(faces);
+    for(auto const& region : regions)
+    {
+        auto const face = std::ranges::find_if(
+            faces,
+            [&](auto const& candidate)
+            { return candidate.cell == region.cell && candidate.localFace == region.localFace; });
+        REQUIRE(face != faces.cend());
+        double const weight = hase::kernels::pumpEntryWeight(region, source.profile);
+        entryWeights[static_cast<std::size_t>(std::distance(faces.cbegin(), face))] += weight;
+        totalEntryWeight += weight;
+    }
+
+    constexpr unsigned rayCount = 1000u;
+    auto const rays = hase::kernels::samplePumpSource(mesh, source, rayCount, 91u);
+    std::array<unsigned, 4u> visits{};
+    for(auto const& ray : rays)
+    {
+        auto const face = std::ranges::find_if(
+            faces,
+            [&](auto const& candidate)
+            { return candidate.cell == ray.cell && static_cast<int>(candidate.localFace) == ray.forbiddenFace; });
+        REQUIRE(face != faces.cend());
+        ++visits[static_cast<std::size_t>(std::distance(faces.cbegin(), face))];
+    }
+
+    for(std::size_t face = 0u; face < faces.size(); ++face)
+    {
+        double const expected = rayCount * entryWeights[face] / totalEntryWeight;
+        CHECK(std::abs(static_cast<double>(visits[face]) - expected) < 1.0);
+    }
+}
+
+TEST_CASE("pump entry stratification is stable across ray partitions", "[pump][source]")
+{
+    auto const mesh = makeSingleTetMesh();
+    auto source = uniformSource(10u);
+    source.surfaces = {7, 8, 9, 10};
+
+    auto const complete = hase::kernels::samplePumpSource(mesh, source, 80u, 17u);
+    auto const partition = hase::kernels::samplePumpSource(mesh, source, 80u, 17u, 31u, 23u);
+    REQUIRE(partition.size() == 23u);
+    for(std::size_t ray = 0u; ray < partition.size(); ++ray)
+    {
+        auto const& expected = complete[31u + ray];
+        auto const& sampled = partition[ray];
+        CHECK(sampled.position.x == expected.position.x);
+        CHECK(sampled.position.y == expected.position.y);
+        CHECK(sampled.position.z == expected.position.z);
+        CHECK(sampled.cell == expected.cell);
+        CHECK(sampled.forbiddenFace == expected.forbiddenFace);
+        CHECK(sampled.wavelength == expected.wavelength);
+    }
+}
+
+TEST_CASE("pump entry CDF lookup clamps a rounded upper boundary", "[pump][source]")
+{
+    std::vector<double> const cdf{0.25, 0.5, 1.0};
+    CHECK(hase::kernels::pumpEntryRegionForTarget(cdf, 0.0) == 0u);
+    CHECK(hase::kernels::pumpEntryRegionForTarget(cdf, 0.25) == 1u);
+    CHECK(hase::kernels::pumpEntryRegionForTarget(cdf, 1.0) == 2u);
+}
+
+TEST_CASE("pump entry sampling accepts an empty global ray range", "[pump][source]")
+{
+    auto const rays = hase::kernels::samplePumpSource(makeSingleTetMesh(), uniformSource(10u), 0u, 17u);
+    CHECK(rays.empty());
 }
 
 TEST_CASE("pump relay preparation encodes physical exit and entry surfaces", "[pump][relay]")


### PR DESCRIPTION
- Stratify pump entry positions over spatial subregions of the injector aperture.
- Weight the entry CDF by the integrated pump profile using triangle quadrature.
- Use global ray indices and a seeded randomized offset to preserve coverage across MPI/device partitions.
- Retain continuous-profile rejection sampling within each selected region.
- Add coverage for nonuniform profiles, partition stability, CDF boundaries, and empty ray ranges.
- Document the pump entry sampling behavior.