### PR TITLE
Resolve automatic openPMD backend for compiled simulations

### DIFF
--- a/include/core/calcPhiAseThreaded.hpp
+++ b/include/core/calcPhiAseThreaded.hpp
@@ -164,7 +164,7 @@ namespace hase::core
     };
 
     /** @brief Identity and collective dispatch for one-thread/one-device workers. */
-    template<alpaka::onHost::concepts::Device T_Device, typename T_Exec>
+    template<alpaka::onHost::concepts::Device T_Device, alpaka::concepts::Executor T_Exec>
     struct HaseWorkerDispatch<ThreadOwnedDevices<T_Device, T_Exec>>
     {
         using T_Policy = ThreadOwnedDevices<T_Device, T_Exec>;
@@ -207,7 +207,7 @@ namespace hase::core
     };
 
     /** @brief Execute one complete forward-ray batch on one thread-owned device. */
-    template<alpaka::onHost::concepts::Device T_Device, typename T_Exec>
+    template<alpaka::onHost::concepts::Device T_Device, alpaka::concepts::Executor T_Exec>
     struct HaseWorkItemDispatch<ThreadOwnedDevices<T_Device, T_Exec>, ForwardRayBatch>
     {
         using T_Policy = ThreadOwnedDevices<T_Device, T_Exec>;
@@ -230,7 +230,7 @@ namespace hase::core
     };
 
     /** @brief Finalize gathered batches on one thread-owned device. */
-    template<alpaka::onHost::concepts::Device T_Device, typename T_Exec>
+    template<alpaka::onHost::concepts::Device T_Device, alpaka::concepts::Executor T_Exec>
     struct HaseWorkItemDispatch<ThreadOwnedDevices<T_Device, T_Exec>, FinalizeForwardAse>
     {
         using T_Policy = ThreadOwnedDevices<T_Device, T_Exec>;

--- a/include/core/forwardPhiAseEvaluator.hpp
+++ b/include/core/forwardPhiAseEvaluator.hpp
@@ -100,7 +100,7 @@ namespace hase::core
             localResults.emplace_back(worker(
                 ForwardRayBatch{
                     batch,
-                    hase::kernels::forward::rseBatchRayCount(0u, launchRayCount, batch, batchCount),
+                    kernels::forward::rseBatchRayCount(0u, launchRayCount, batch, batchCount),
                     launchSeed}));
         }
         return localResults;
@@ -143,13 +143,23 @@ namespace hase::core
             context.batchCount);
         simulation.convergenceRayCounts.assign(context.hostMesh.numberOfCells, 0u);
         unsigned const baseSeed = worker.scatter(context.baseSeed);
-
+        // adaptive sampling loop
         for(unsigned completedIncreases = 0u;; ++completedIncreases)
         {
             unsigned const targetRayCount = adaptiveRayTarget(context.experiment, context.compute, completedIncreases);
             unsigned const launchRayCount = targetRayCount - simulation.raw.rayCount;
             unsigned const launchSeed = random::seedForAdaptiveLaunch(baseSeed, simulation.adaptiveLaunches);
-            auto localResults = executeMappedBatches(worker, launchRayCount, launchSeed, context.batchCount);
+
+            ForwardRayBatchResults localResults;
+            // batch loop
+            for(auto [batch] : hase::mapIdx(worker, alpaka::IdxRange{context.batchCount}))
+            {
+                localResults.emplace_back(worker(
+                    ForwardRayBatch{
+                        batch,
+                        kernels::forward::rseBatchRayCount(0u, launchRayCount, batch, context.batchCount),
+                        launchSeed}));
+            }
             float const localRuntime = std::accumulate(
                 localResults.cbegin(),
                 localResults.cend(),

--- a/pyInclude/openpmd/transport.py
+++ b/pyInclude/openpmd/transport.py
@@ -1960,9 +1960,8 @@ def runSimulation(
     steps = int(steps)
     if steps <= 0:
         raise ValueError("steps must be positive")
-    spec = _backend_spec(transport)
-    _ensure_backend_available(spec.name)
     executable = findCalcPhiAse()
+    spec = _ensure_backend_available(transport, executable)
     run_control = _simulation_run_control(simulation, steps=steps, pumpSteps=pumpSteps)
     if simulation.executionMode == "synchronized-debug" and not spec.streaming:
         raise ValueError("synchronized-debug requires an openPMD streaming backend")

--- a/tests/python/openpmd/test_transport.py
+++ b/tests/python/openpmd/test_transport.py
@@ -500,6 +500,43 @@ def test_autoBackendPrefersAdiosThenSstThenHdf5(monkeypatch, tmp_path):
     assert transport._ensure_backend_available("auto", executable).name == "hdf5"
 
 
+def test_runSimulationResolvesAutoAgainstRuntime(monkeypatch, tmp_path):
+    executable = tmp_path / "calcPhiASE"
+    executable.write_text("", encoding="utf-8")
+    resolved = transport.OPENPMD_BACKENDS["hdf5"]
+    resolution_calls = []
+    written = []
+
+    monkeypatch.setattr(transport, "findCalcPhiAse", lambda: executable)
+
+    def resolve_backend(backend, selected_executable):
+        resolution_calls.append((backend, selected_executable))
+        return resolved
+
+    monkeypatch.setattr(transport, "_ensure_backend_available", resolve_backend)
+    monkeypatch.setattr(transport, "_simulation_run_control", lambda *args, **kwargs: {})
+    monkeypatch.setattr(transport, "_artifact_root", lambda: tmp_path)
+    monkeypatch.setattr(transport, "_artifact_run_id", lambda: "auto")
+    monkeypatch.setattr(
+        transport,
+        "_write_simulation_input",
+        lambda input_path, spec, simulation, run_control: written.append((input_path, spec)),
+    )
+    monkeypatch.setattr(
+        transport.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(transport, "read_simulation_output", lambda output_path, on_state=None: output_path)
+
+    simulation = SimpleNamespace(executionMode="autonomous")
+    output_path = transport.runSimulation(simulation, steps=1, transport="auto")
+
+    assert resolution_calls == [("auto", executable)]
+    assert written == [(tmp_path / "auto-input.h5", resolved)]
+    assert output_path == tmp_path / "auto-output.h5"
+
+
 def test_openPmdBackendProbeIsCachedPerExecutable(monkeypatch, tmp_path):
     transport._OPENPMD_BACKEND_PROBE_CACHE.clear()
     executable = tmp_path / "calcPhiASE"


### PR DESCRIPTION
- Resolve the automatic openPMD backend against the installed native runtime before constructing compiled simulation transport paths.
- Keep the resolved backend consistent for simulation input and output.
- Add regression coverage for automatic runtime resolution.