### PR TITLE
Fix gitlab CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  gitlab-extended-ci-gate:
+    name: Initialize CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Admit CI workflows
+        run: "true"
+
   pre-commit:
+    needs: gitlab-extended-ci-gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,6 +24,7 @@ jobs:
         run: bash script/ci/pre-commit.sh
 
   ci:
+    needs: gitlab-extended-ci-gate
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.config.container }}
@@ -95,6 +104,7 @@ jobs:
         run: bash script/ci/test-pytest.sh
 
   openpmd-provider-smoke:
+    needs: gitlab-extended-ci-gate
     runs-on: ubuntu-latest
     container:
       image: ubuntu:24.04

--- a/.github/workflows/gitlab-extended-ci.yml
+++ b/.github/workflows/gitlab-extended-ci.yml
@@ -1,8 +1,8 @@
 name: GitLab extended CI
 
 # Configure "Require approval for all external contributors" under
-# Settings > Actions > General. The bridge starts with the approved CI run, so
-# one maintainer approval gates both GitHub and GitLab computation.
+# Settings > Actions > General. The bridge starts when the approved CI gate job
+# begins, so one maintainer approval gates both GitHub and GitLab computation.
 on:
   workflow_run:
     workflows:
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   gitlab-extended-ci:
@@ -27,9 +28,14 @@ jobs:
       HASE_SOURCE_REF: ${{ github.event.workflow_run.head_branch }}
       HASE_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
       HASE_GITHUB_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      HASE_GITHUB_REPOSITORY: ${{ github.repository }}
+      HASE_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
+          # workflow_run uses a trusted default-branch SHA. Never check out the
+          # untrusted source SHA in this job because it has access to secrets.
+          ref: ${{ github.sha }}
           persist-credentials: false
       - name: Trigger GitLab extended CI and wait
         run: python3 script/ci/run-gitlab-extended-ci.py

--- a/include/kernels/generalPump.hpp
+++ b/include/kernels/generalPump.hpp
@@ -107,7 +107,7 @@ namespace hase::kernels
                     continue;
                 info.area = 0.5 * twiceArea;
                 info.normal = normal * (1.0 / twiceArea);
-                hase::core::Point const center{
+                core::Point const center{
                     mesh.cellCenters[cell],
                     mesh.cellCenters[cell + mesh.numberOfCells],
                     mesh.cellCenters[cell + 2u * mesh.numberOfCells]};
@@ -129,7 +129,7 @@ namespace hase::kernels
 
     [[nodiscard]] inline hase::core::Point perpendicular(hase::core::Point const normal)
     {
-        hase::core::Point reference
+        core::Point reference
             = std::abs(normal.x) < 0.9 ? hase::core::Point{1.0, 0.0, 0.0} : hase::core::Point{0.0, 1.0, 0.0};
         return hostNormalize(hase::core::cross(normal, reference));
     }

--- a/script/ci/run-gitlab-extended-ci.py
+++ b/script/ci/run-gitlab-extended-ci.py
@@ -17,8 +17,18 @@ from pathlib import Path
 
 GITLAB_API_URL = "https://codebase.helmholtz.cloud/api/v4"
 GITLAB_PIPELINE_REF = "master"
+GITLAB_WEB_HOST = "codebase.helmholtz.cloud"
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_API_VERSION = "2026-03-10"
+GITHUB_STATUS_CONTEXT = "ci/gitlab/codebase.helmholtz.cloud"
+GITHUB_REPOSITORY_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/"
+    r"[A-Za-z0-9._-]{1,100}"
+)
+RETRY_DELAY_SECONDS = 5
 POLL_INTERVAL_SECONDS = 15
-TIMEOUT_SECONDS = 6 * 60 * 60
+# Leave time to publish an error before the 360-minute workflow timeout.
+TIMEOUT_SECONDS = 355 * 60
 
 TRANSIENT_STATUSES = {
     "created",
@@ -38,23 +48,39 @@ def required_environment(name: str) -> str:
     return value
 
 
+def github_repository_environment(name: str) -> str:
+    value = required_environment(name)
+    if not GITHUB_REPOSITORY_PATTERN.fullmatch(value):
+        raise RuntimeError(f"{name} must have the form owner/repository")
+    _, repository = value.split("/", maxsplit=1)
+    if repository in {".", ".."}:
+        raise RuntimeError(f"{name} must have the form owner/repository")
+    return value
+
+
 def request_json(
     request: urllib.request.Request,
     *,
     attempts: int = 1,
+    service: str = "GitLab",
 ) -> dict[str, object]:
     for attempt in range(1, attempts + 1):
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
-                return json.load(response)
+                payload = json.load(response)
+            if not isinstance(payload, dict):
+                raise RuntimeError(f"{service} API returned a non-object response")
+            return payload
         except urllib.error.HTTPError as error:
             raise RuntimeError(
-                f"GitLab API request failed: HTTP {error.code} {error.reason}"
+                f"{service} API request failed: HTTP {error.code} {error.reason}"
             ) from error
         except (urllib.error.URLError, TimeoutError) as error:
             if attempt == attempts:
-                raise RuntimeError(f"GitLab API request failed: {error}") from error
-            time.sleep(min(5 * attempt, POLL_INTERVAL_SECONDS))
+                raise RuntimeError(f"{service} API request failed: {error}") from error
+            time.sleep(RETRY_DELAY_SECONDS * attempt)
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise RuntimeError(f"{service} API returned invalid JSON") from error
     raise AssertionError("unreachable")
 
 
@@ -87,61 +113,190 @@ def get_pipeline(
     return request_json(request, attempts=3)
 
 
-def append_step_summary(pipeline_id: int, source_sha: str) -> None:
+def post_commit_status(
+    repository: str,
+    source_sha: str,
+    github_token: str,
+    state: str,
+    description: str,
+    target_url: str,
+) -> None:
+    payload = {
+        "state": state,
+        "context": GITHUB_STATUS_CONTEXT,
+        "description": description,
+        "target_url": target_url,
+    }
+    request = urllib.request.Request(
+        f"{GITHUB_API_URL}/repos/{repository}/statuses/{source_sha}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {github_token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+        method="POST",
+    )
+    request_json(request, attempts=3, service="GitHub")
+
+
+def append_step_summary(
+    pipeline_id: int, source_sha: str, pipeline_url: str
+) -> None:
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
     with Path(summary_path).open("a", encoding="utf-8") as summary:
         summary.write("## GitLab extended CI\n\n")
         summary.write(f"- Source commit: `{source_sha}`\n")
-        summary.write(f"- Pipeline ID: `{pipeline_id}`\n")
+        summary.write(f"- Pipeline: [#{pipeline_id}]({pipeline_url})\n")
+
+
+def pipeline_web_url(
+    pipeline: dict[str, object], pipeline_id: int, project_id: str
+) -> str:
+    try:
+        response_project_id = int(pipeline["project_id"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise RuntimeError(
+            "GitLab trigger response did not identify the expected project"
+        ) from error
+    if response_project_id != int(project_id):
+        raise RuntimeError(
+            "GitLab trigger response did not identify the expected project"
+        )
+
+    value = pipeline.get("web_url")
+    if isinstance(value, str):
+        parsed = urllib.parse.urlparse(value)
+        if (
+            parsed.scheme == "https"
+            and parsed.netloc == GITLAB_WEB_HOST
+            and parsed.path.endswith(f"/-/pipelines/{pipeline_id}")
+            and not parsed.params
+            and not parsed.query
+            and not parsed.fragment
+        ):
+            return value
+    raise RuntimeError(
+        "GitLab trigger response did not include the expected pipeline URL"
+    )
 
 
 def main() -> int:
-    project_id = required_environment("HASE_GITLAB_PROJECT_ID")
-    if not re.fullmatch(r"[1-9][0-9]*", project_id):
-        raise RuntimeError("HASE_GITLAB_PROJECT_ID must be a positive integer")
-    pipeline_ref = os.environ.get("HASE_GITLAB_PIPELINE_REF", GITLAB_PIPELINE_REF)
-    trigger_token = required_environment("HASE_GITLAB_TRIGGER_TOKEN")
-    read_token = required_environment("HASE_GITLAB_READ_API_TOKEN")
     source_sha = required_environment("HASE_SOURCE_SHA").lower()
     if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
         raise RuntimeError("HASE_SOURCE_SHA must be a full hexadecimal Git commit")
+    github_repository = github_repository_environment("HASE_GITHUB_REPOSITORY")
+    github_token = required_environment("HASE_GITHUB_TOKEN")
+    github_run_url = required_environment("HASE_GITHUB_RUN_URL")
+    pipeline_url = github_run_url
 
-    variables = {
-        "HASE_SOURCE_SHA": source_sha,
-        "HASE_SOURCE_EVENT": os.environ.get("HASE_SOURCE_EVENT", "unknown"),
-        "HASE_SOURCE_REF": os.environ.get("HASE_SOURCE_REF", "unknown"),
-        "HASE_PR_NUMBER": os.environ.get("HASE_PR_NUMBER", ""),
-        "HASE_GITHUB_RUN_URL": os.environ.get("HASE_GITHUB_RUN_URL", ""),
-    }
-    pipeline = trigger_pipeline(project_id, pipeline_ref, trigger_token, variables)
     try:
-        pipeline_id = int(pipeline["id"])
-    except (KeyError, TypeError, ValueError) as error:
-        raise RuntimeError("GitLab trigger response did not identify a pipeline") from error
+        project_id = required_environment("HASE_GITLAB_PROJECT_ID")
+        if not re.fullmatch(r"[1-9][0-9]*", project_id):
+            raise RuntimeError("HASE_GITLAB_PROJECT_ID must be a positive integer")
+        pipeline_ref = os.environ.get(
+            "HASE_GITLAB_PIPELINE_REF", GITLAB_PIPELINE_REF
+        )
+        trigger_token = required_environment("HASE_GITLAB_TRIGGER_TOKEN")
+        read_token = required_environment("HASE_GITLAB_READ_API_TOKEN")
+        source_repository = github_repository_environment("HASE_SOURCE_REPOSITORY")
 
-    print(f"Triggered GitLab pipeline {pipeline_id}", flush=True)
-    append_step_summary(pipeline_id, source_sha)
+        variables = {
+            "HASE_SOURCE_SHA": source_sha,
+            "HASE_SOURCE_REPOSITORY": source_repository,
+            "HASE_SOURCE_EVENT": os.environ.get("HASE_SOURCE_EVENT", "unknown"),
+            "HASE_SOURCE_REF": os.environ.get("HASE_SOURCE_REF", "unknown"),
+            "HASE_PR_NUMBER": os.environ.get("HASE_PR_NUMBER", ""),
+            "HASE_GITHUB_RUN_URL": github_run_url,
+        }
+        pipeline = trigger_pipeline(project_id, pipeline_ref, trigger_token, variables)
+        try:
+            pipeline_id = int(pipeline["id"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise RuntimeError(
+                "GitLab trigger response did not identify a pipeline"
+            ) from error
+        if pipeline_id <= 0:
+            raise RuntimeError("GitLab trigger response did not identify a pipeline")
 
-    deadline = time.monotonic() + TIMEOUT_SECONDS
-    previous_status = ""
-    while True:
-        pipeline = get_pipeline(project_id, pipeline_id, read_token)
-        status = str(pipeline.get("status", ""))
-        if status != previous_status:
-            print(f"GitLab pipeline {pipeline_id}: {status}", flush=True)
-            previous_status = status
+        pipeline_url = pipeline_web_url(pipeline, pipeline_id, project_id)
+        print(f"Triggered GitLab pipeline {pipeline_id}", flush=True)
+        append_step_summary(pipeline_id, source_sha, pipeline_url)
+        post_commit_status(
+            github_repository,
+            source_sha,
+            github_token,
+            "pending",
+            f"GitLab pipeline {pipeline_id} is in progress",
+            pipeline_url,
+        )
 
-        if status == "success":
-            return 0
-        if status not in TRANSIENT_STATUSES:
-            print(f"GitLab pipeline {pipeline_id} did not succeed", file=sys.stderr)
-            return 1
-        if time.monotonic() >= deadline:
-            print(f"Timed out waiting for GitLab pipeline {pipeline_id}", file=sys.stderr)
-            return 1
-        time.sleep(POLL_INTERVAL_SECONDS)
+        deadline = time.monotonic() + TIMEOUT_SECONDS
+        previous_status = ""
+        while True:
+            pipeline = get_pipeline(project_id, pipeline_id, read_token)
+            status = str(pipeline.get("status", ""))
+            if status != previous_status:
+                print(f"GitLab pipeline {pipeline_id}: {status}", flush=True)
+                previous_status = status
+
+            if status == "success":
+                post_commit_status(
+                    github_repository,
+                    source_sha,
+                    github_token,
+                    "success",
+                    f"GitLab pipeline {pipeline_id} succeeded",
+                    pipeline_url,
+                )
+                return 0
+            if status not in TRANSIENT_STATUSES:
+                post_commit_status(
+                    github_repository,
+                    source_sha,
+                    github_token,
+                    "failure",
+                    f"GitLab pipeline {pipeline_id} finished with status {status}",
+                    pipeline_url,
+                )
+                print(
+                    f"GitLab pipeline {pipeline_id} did not succeed", file=sys.stderr
+                )
+                return 1
+            if time.monotonic() >= deadline:
+                post_commit_status(
+                    github_repository,
+                    source_sha,
+                    github_token,
+                    "error",
+                    f"Timed out waiting for GitLab pipeline {pipeline_id}",
+                    pipeline_url,
+                )
+                print(
+                    f"Timed out waiting for GitLab pipeline {pipeline_id}",
+                    file=sys.stderr,
+                )
+                return 1
+            time.sleep(POLL_INTERVAL_SECONDS)
+    except RuntimeError:
+        try:
+            post_commit_status(
+                github_repository,
+                source_sha,
+                github_token,
+                "error",
+                "GitLab bridge failed before the pipeline completed",
+                pipeline_url,
+            )
+        except RuntimeError as status_error:
+            print(
+                f"Additionally failed to update GitHub status: {status_error}",
+                file=sys.stderr,
+            )
+        raise
 
 
 if __name__ == "__main__":

--- a/tests/python/ci/test_run_gitlab_extended_ci.py
+++ b/tests/python/ci/test_run_gitlab_extended_ci.py
@@ -1,0 +1,265 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "script" / "ci" / "run-gitlab-extended-ci.py"
+)
+SPEC = importlib.util.spec_from_file_location("run_gitlab_extended_ci", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+BRIDGE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BRIDGE)
+
+SOURCE_SHA = "a" * 40
+GITHUB_RUN_URL = "https://github.com/example/haseongpu/actions/runs/123"
+GITLAB_PIPELINE_URL = (
+    "https://codebase.helmholtz.cloud/th168408/"
+    "haseongpu-extended-ci/-/pipelines/42"
+)
+
+
+def configure_environment(monkeypatch):
+    environment = {
+        "HASE_SOURCE_SHA": SOURCE_SHA,
+        "HASE_SOURCE_REPOSITORY": "contributor/haseongpu",
+        "HASE_GITHUB_REPOSITORY": "example/haseongpu",
+        "HASE_GITHUB_TOKEN": "github-token",
+        "HASE_GITHUB_RUN_URL": GITHUB_RUN_URL,
+        "HASE_GITLAB_PROJECT_ID": "1234",
+        "HASE_GITLAB_TRIGGER_TOKEN": "trigger-token",
+        "HASE_GITLAB_READ_API_TOKEN": "read-token",
+        "HASE_SOURCE_EVENT": "pull_request",
+        "HASE_SOURCE_REF": "feature",
+        "HASE_PR_NUMBER": "206",
+    }
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+
+def record_statuses(monkeypatch):
+    statuses = []
+
+    def record(repository, source_sha, token, state, description, target_url):
+        statuses.append(
+            {
+                "repository": repository,
+                "source_sha": source_sha,
+                "token": token,
+                "state": state,
+                "description": description,
+                "target_url": target_url,
+            }
+        )
+
+    monkeypatch.setattr(BRIDGE, "post_commit_status", record)
+    return statuses
+
+
+def configure_pipeline(monkeypatch):
+    configure_environment(monkeypatch)
+    triggered = {}
+
+    def trigger(project_id, pipeline_ref, trigger_token, variables):
+        triggered.update(
+            {
+                "project_id": project_id,
+                "pipeline_ref": pipeline_ref,
+                "trigger_token": trigger_token,
+                "variables": variables,
+            }
+        )
+        return {
+            "id": 42,
+            "project_id": 1234,
+            "web_url": GITLAB_PIPELINE_URL,
+        }
+
+    monkeypatch.setattr(
+        BRIDGE,
+        "trigger_pipeline",
+        trigger,
+    )
+    monkeypatch.setattr(BRIDGE.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(BRIDGE, "append_step_summary", lambda *args: None)
+    return triggered
+
+
+def test_post_commit_status_uses_github_status_api(monkeypatch):
+    captured = {}
+
+    def capture(request, *, attempts=1, service="GitLab"):
+        captured["request"] = request
+        captured["attempts"] = attempts
+        captured["service"] = service
+        return {}
+
+    monkeypatch.setattr(BRIDGE, "request_json", capture)
+
+    BRIDGE.post_commit_status(
+        "example/haseongpu",
+        SOURCE_SHA,
+        "github-token",
+        "pending",
+        "GitLab pipeline is pending",
+        GITLAB_PIPELINE_URL,
+    )
+
+    request = captured["request"]
+    assert request.full_url == (
+        f"https://api.github.com/repos/example/haseongpu/statuses/{SOURCE_SHA}"
+    )
+    assert request.method == "POST"
+    assert request.get_header("Authorization") == "Bearer github-token"
+    assert request.get_header("X-github-api-version") == "2026-03-10"
+    assert captured["attempts"] == 3
+    assert captured["service"] == "GitHub"
+    assert json.loads(request.data) == {
+        "state": "pending",
+        "context": "ci/gitlab/codebase.helmholtz.cloud",
+        "description": "GitLab pipeline is pending",
+        "target_url": GITLAB_PIPELINE_URL,
+    }
+
+
+def test_success_updates_pending_status_and_pipeline_result(monkeypatch):
+    statuses = record_statuses(monkeypatch)
+    triggered = configure_pipeline(monkeypatch)
+    pipelines = iter([{"status": "running"}, {"status": "success"}])
+    monkeypatch.setattr(
+        BRIDGE,
+        "get_pipeline",
+        lambda project_id, pipeline_id, read_token: next(pipelines),
+    )
+
+    assert BRIDGE.main() == 0
+
+    assert triggered["project_id"] == "1234"
+    assert triggered["pipeline_ref"] == "master"
+    assert triggered["trigger_token"] == "trigger-token"
+    assert triggered["variables"] == {
+        "HASE_SOURCE_SHA": SOURCE_SHA,
+        "HASE_SOURCE_REPOSITORY": "contributor/haseongpu",
+        "HASE_SOURCE_EVENT": "pull_request",
+        "HASE_SOURCE_REF": "feature",
+        "HASE_PR_NUMBER": "206",
+        "HASE_GITHUB_RUN_URL": GITHUB_RUN_URL,
+    }
+    assert [status["state"] for status in statuses] == ["pending", "success"]
+    assert statuses[0]["target_url"] == GITLAB_PIPELINE_URL
+    assert statuses[1]["target_url"] == GITLAB_PIPELINE_URL
+
+
+def test_failed_pipeline_updates_failure_status(monkeypatch):
+    statuses = record_statuses(monkeypatch)
+    configure_pipeline(monkeypatch)
+    monkeypatch.setattr(
+        BRIDGE,
+        "get_pipeline",
+        lambda project_id, pipeline_id, read_token: {"status": "failed"},
+    )
+
+    assert BRIDGE.main() == 1
+
+    assert [status["state"] for status in statuses] == ["pending", "failure"]
+    assert statuses[-1]["target_url"] == GITLAB_PIPELINE_URL
+
+
+def test_timeout_updates_error_status(monkeypatch):
+    statuses = record_statuses(monkeypatch)
+    configure_pipeline(monkeypatch)
+    monkeypatch.setattr(BRIDGE, "TIMEOUT_SECONDS", 0)
+    monkeypatch.setattr(
+        BRIDGE,
+        "get_pipeline",
+        lambda project_id, pipeline_id, read_token: {"status": "running"},
+    )
+
+    assert BRIDGE.main() == 1
+
+    assert [status["state"] for status in statuses] == ["pending", "error"]
+    assert "Timed out" in statuses[-1]["description"]
+    assert statuses[-1]["target_url"] == GITLAB_PIPELINE_URL
+
+
+def test_trigger_error_updates_error_status(monkeypatch):
+    configure_environment(monkeypatch)
+    statuses = record_statuses(monkeypatch)
+
+    def fail_trigger(project_id, pipeline_ref, trigger_token, variables):
+        raise RuntimeError("trigger failed")
+
+    monkeypatch.setattr(BRIDGE, "trigger_pipeline", fail_trigger)
+
+    with pytest.raises(RuntimeError, match="trigger failed"):
+        BRIDGE.main()
+
+    assert [status["state"] for status in statuses] == ["error"]
+    assert statuses[-1]["target_url"] == GITHUB_RUN_URL
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        "https://github.com/contributor/haseongpu.git",
+        "contributor",
+        "contributor/../haseongpu",
+        "contributor/..",
+        "contributor/haseongpu extra",
+        "-contributor/haseongpu",
+        "contributor-/haseongpu",
+    ],
+)
+def test_invalid_source_repository_is_rejected(monkeypatch, repository):
+    configure_environment(monkeypatch)
+    monkeypatch.setenv("HASE_SOURCE_REPOSITORY", repository)
+    statuses = record_statuses(monkeypatch)
+
+    def unexpected_trigger(*args):
+        raise AssertionError("invalid source repository reached the GitLab trigger")
+
+    monkeypatch.setattr(BRIDGE, "trigger_pipeline", unexpected_trigger)
+
+    with pytest.raises(RuntimeError, match="HASE_SOURCE_REPOSITORY"):
+        BRIDGE.main()
+
+    assert [status["state"] for status in statuses] == ["error"]
+    assert statuses[0]["target_url"] == GITHUB_RUN_URL
+
+
+@pytest.mark.parametrize(
+    "pipeline",
+    [
+        {"id": 42, "project_id": 1234},
+        {
+            "id": 42,
+            "project_id": 1234,
+            "web_url": "https://codebase.example/pipelines/42",
+        },
+        {
+            "id": 42,
+            "project_id": 4321,
+            "web_url": (
+                "https://codebase.helmholtz.cloud/th168408/"
+                "haseongpu-extended-ci/-/pipelines/42"
+            ),
+        },
+    ],
+)
+def test_invalid_pipeline_url_updates_error_status(monkeypatch, pipeline):
+    configure_environment(monkeypatch)
+    statuses = record_statuses(monkeypatch)
+    monkeypatch.setattr(
+        BRIDGE,
+        "trigger_pipeline",
+        lambda project_id, pipeline_ref, trigger_token, variables: pipeline,
+    )
+
+    with pytest.raises(RuntimeError, match="expected"):
+        BRIDGE.main()
+
+    assert [status["state"] for status in statuses] == ["error"]
+    assert statuses[0]["target_url"] == GITHUB_RUN_URL


### PR DESCRIPTION
This PR makes the existing GitLab extended-CI bridge start reliably through a dedicated Initialize CI gate aligned with the normal CI approval flow. It mirrors the GitLab pipeline result
  into a clickable GitHub commit status, validates the returned pipeline URL, and handles failures and timeouts robustly. It adds focused bridge tests and fixes the generalPump point
  namespace qualification found by CI.